### PR TITLE
feat(mcp): expose plugin on dedicated /wp-json/mcp/rt-publish-with-ai server

### DIFF
--- a/inc/Main.php
+++ b/inc/Main.php
@@ -30,6 +30,7 @@ final class Main {
 		Modules\Settings\Settings::class,
 		Modules\MCP\OAuth\OAuth::class,
 		Modules\MCP\Abilities\Abilities::class,
+		Modules\MCP\Server\Server::class,
 	];
 
 	/**

--- a/inc/Modules/MCP/Abilities/Abilities.php
+++ b/inc/Modules/MCP/Abilities/Abilities.php
@@ -32,7 +32,6 @@ use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Search_Posts;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Set_Featured_Image;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Update_Post;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Upload_Media;
-use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Resources\Content_Generation_Guide;
 
 /**
  * Class - Abilities
@@ -44,7 +43,6 @@ final class Abilities implements Registrable {
 	public function register_hooks(): void {
 		add_action( 'wp_abilities_api_categories_init', [ $this, 'register_categories' ] );
 		add_action( 'wp_abilities_api_init', [ $this, 'register_abilities' ] );
-		add_filter( 'mcp_adapter_default_server_config', [ $this, 'register_resources' ] );
 	}
 
 	/**
@@ -99,24 +97,5 @@ final class Abilities implements Registrable {
 		foreach ( $abilities as $ability ) {
 			$ability->register();
 		}
-	}
-
-	/**
-	 * Register MCP resources.
-	 *
-	 * @param array<string, mixed> $config MCP server config.
-	 *
-	 * @return array<string, mixed>
-	 */
-	public function register_resources( array $config ): array {
-		$resources = [
-			new Content_Generation_Guide(),
-		];
-
-		foreach ( $resources as $resource ) {
-			$config = $resource->add_resource( $config );
-		}
-
-		return $config;
 	}
 }

--- a/inc/Modules/MCP/OAuth/Config.php
+++ b/inc/Modules/MCP/OAuth/Config.php
@@ -14,7 +14,7 @@ namespace rtCamp\Publish_With_AI\Modules\MCP\OAuth;
  */
 class Config {
 	public const MCP_ROUTE_NAMESPACE    = 'mcp';
-	public const MCP_ROUTE              = 'mcp-adapter-default-server';
+	public const MCP_ROUTE              = 'rt-publish-with-ai';
 	public const OAUTH_REST_NAMESPACE   = 'rtpwai-oauth/v1';
 	public const ACCESS_TOKEN_TTL       = 3600;
 	public const REFRESH_TOKEN_TTL      = 2592000;

--- a/inc/Modules/MCP/Server/Server.php
+++ b/inc/Modules/MCP/Server/Server.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Registers the dedicated Publish with AI MCP server.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\MCP\Server
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\MCP\Server;
+
+use WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler;
+use WP\MCP\Transport\HttpTransport;
+use rtCamp\Publish_With_AI\Framework\Contracts\Interfaces\Registrable;
+use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Resources\Content_Generation_Guide;
+
+/**
+ * Class - Server
+ */
+class Server implements Registrable {
+	private const SERVER_ID = 'rt-publish-with-ai';
+
+	private const TOOLS = [
+		'rtpwai/get-patterns',
+		'rtpwai/get-pattern',
+		'rtpwai/get-pattern-schema',
+		'rtpwai/apply-pattern-schema',
+		'rtpwai/get-custom-blocks',
+		'rtpwai/get-block',
+		'rtpwai/render-block',
+		'rtpwai/create-post',
+		'rtpwai/get-post',
+		'rtpwai/update-post',
+		'rtpwai/set-featured-image',
+		'rtpwai/append-blocks',
+		'rtpwai/insert-blocks-at',
+		'rtpwai/append-pattern',
+		'rtpwai/insert-pattern-at',
+		'rtpwai/delete-block-at',
+		'rtpwai/search-posts',
+		'rtpwai/search-attachments',
+		'rtpwai/upload-media',
+	];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks(): void {
+		add_action( 'mcp_adapter_init', [ $this, 'create' ] );
+	}
+
+	/**
+	 * Create and register the dedicated MCP server.
+	 *
+	 * @param \WP\MCP\Core\McpAdapter $adapter The MCP Adapter instance.
+	 */
+	public function create( \WP\MCP\Core\McpAdapter $adapter ): void {
+		$guide_config = ( new Content_Generation_Guide() )->add_resource( [] );
+		$resources    = $guide_config['resources'] ?? [];
+
+		$adapter->create_server(
+			self::SERVER_ID,
+			'mcp',
+			self::SERVER_ID,
+			__( 'Publish with AI', 'rtcamp-publish-with-ai' ),
+			__( 'MCP server for the Publish with AI plugin.', 'rtcamp-publish-with-ai' ),
+			RTCAMP_PUBLISH_WITH_AI_VERSION,
+			[ HttpTransport::class ],
+			ErrorLogMcpErrorHandler::class,
+			null,
+			self::TOOLS,
+			$resources,
+		);
+	}
+}

--- a/inc/Modules/MCP/Server/Server.php
+++ b/inc/Modules/MCP/Server/Server.php
@@ -18,29 +18,8 @@ use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Resources\Content_Generation_Gu
  * Class - Server
  */
 class Server implements Registrable {
-	private const SERVER_ID = 'rt-publish-with-ai';
-
-	private const TOOLS = [
-		'rtpwai/get-patterns',
-		'rtpwai/get-pattern',
-		'rtpwai/get-pattern-schema',
-		'rtpwai/apply-pattern-schema',
-		'rtpwai/get-custom-blocks',
-		'rtpwai/get-block',
-		'rtpwai/render-block',
-		'rtpwai/create-post',
-		'rtpwai/get-post',
-		'rtpwai/update-post',
-		'rtpwai/set-featured-image',
-		'rtpwai/append-blocks',
-		'rtpwai/insert-blocks-at',
-		'rtpwai/append-pattern',
-		'rtpwai/insert-pattern-at',
-		'rtpwai/delete-block-at',
-		'rtpwai/search-posts',
-		'rtpwai/search-attachments',
-		'rtpwai/upload-media',
-	];
+	private const SERVER_ID      = 'rt-publish-with-ai';
+	private const ABILITY_PREFIX = 'rtpwai/';
 
 	/**
 	 * {@inheritDoc}
@@ -68,8 +47,25 @@ class Server implements Registrable {
 			[ HttpTransport::class ],
 			ErrorLogMcpErrorHandler::class,
 			null,
-			self::TOOLS,
+			$this->get_tools(),
 			$resources,
 		);
+	}
+
+	/**
+	 * Discover all abilities registered under the rtpwai/ namespace.
+	 *
+	 * @return string[]
+	 */
+	private function get_tools(): array {
+		$tools = [];
+
+		foreach ( wp_get_abilities() as $ability ) {
+			if ( str_starts_with( $ability->get_name(), self::ABILITY_PREFIX ) ) {
+				$tools[] = $ability->get_name();
+			}
+		}
+
+		return $tools;
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `Modules\MCP\Server\Server` class that hooks into `mcp_adapter_init` and registers a dedicated MCP server at `/wp-json/mcp/rt-publish-with-ai`
- All 19 `rtpwai/*` abilities are exposed as direct MCP tools on the server (no generic discovery indirection)
- `Content_Generation_Guide` resource is attached to the dedicated server
- Removes the `mcp_adapter_default_server_config` filter from `Abilities` — the plugin no longer piggybacks on the default server
- Updates `Config::MCP_ROUTE` from `mcp-adapter-default-server` to `rt-publish-with-ai` so OAuth well-known metadata (protected resource fallback, `get_mcp_resource_url()`) points to the correct endpoint

Closes #12

## Test plan

- [ ] Activate plugin alongside `mcp-adapter`; confirm `GET /wp-json/mcp/rt-publish-with-ai` responds
- [ ] Connect via Claude.ai — all 19 tools should appear under the connector (9 read, 10 write/delete)
- [ ] Confirm `/.well-known/oauth-protected-resource/wp-json/mcp/rt-publish-with-ai` returns correct metadata
- [ ] Confirm `/.well-known/oauth-protected-resource` root fallback still works
- [ ] Confirm the default `mcp-adapter-default-server` no longer lists `rtpwai/*` tools or the Content Generation Guide resource