### PR TITLE
feat(screenshot): MCP screenshot-post tool with ephemeral preview URLs

### DIFF
--- a/inc/Core/Assets.php
+++ b/inc/Core/Assets.php
@@ -29,6 +29,7 @@ final class Assets implements Registrable {
 	public const ADMIN_HANDLE             = self::PREFIX . 'admin';
 	public const ADMIN_CONNECTIONS_HANDLE = self::PREFIX . 'admin-connections';
 	public const ADMIN_CREDENTIALS_HANDLE = self::PREFIX . 'admin-credentials';
+	public const ADMIN_SETTINGS_HANDLE    = self::PREFIX . 'admin-settings';
 	public const ADMIN_MENU_ICON_HANDLE   = self::PREFIX . 'admin-menu-icon';
 
 	/**
@@ -38,6 +39,7 @@ final class Assets implements Registrable {
 		self::ADMIN_HANDLE,
 		self::ADMIN_CONNECTIONS_HANDLE,
 		self::ADMIN_CREDENTIALS_HANDLE,
+		self::ADMIN_SETTINGS_HANDLE,
 	];
 
 	/**
@@ -76,6 +78,10 @@ final class Assets implements Registrable {
 		// Credentials page (sub-menu).
 		$this->register_script( self::ADMIN_CREDENTIALS_HANDLE, 'admin-credentials' );
 		$this->register_style( self::ADMIN_CREDENTIALS_HANDLE, 'admin-credentials', [ 'wp-components' ] );
+
+		// Settings page (sub-menu).
+		$this->register_script( self::ADMIN_SETTINGS_HANDLE, 'admin-settings' );
+		$this->register_style( self::ADMIN_SETTINGS_HANDLE, 'admin-settings', [ 'wp-components' ] );
 
 		// Menu icon style (CSS-only entry, loaded on all admin pages).
 		$this->register_style( self::ADMIN_MENU_ICON_HANDLE, 'admin-menu-icon' );

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -31,6 +31,7 @@ final class Main {
 		Modules\Screenshot\Settings::class,
 		Modules\Screenshot\REST_Controller::class,
 		Modules\Screenshot\Preview_Endpoint::class,
+		Modules\Screenshot\Screenshot_Image_Endpoint::class,
 		Modules\MCP\OAuth\OAuth::class,
 		Modules\MCP\Abilities\Abilities::class,
 		Modules\MCP\Server\Server::class,
@@ -59,6 +60,9 @@ final class Main {
 		register_activation_hook( RTCAMP_PUBLISH_WITH_AI_FILE, [ self::class, 'activate' ] );
 		register_deactivation_hook( RTCAMP_PUBLISH_WITH_AI_FILE, [ self::class, 'deactivate' ] );
 
+		// Run schema migrations when the plugin version changes.
+		add_action( 'plugins_loaded', [ self::class, 'maybe_upgrade' ] );
+
 		// Do other stuff here like dep-checking, telemetry, etc.
 	}
 
@@ -81,10 +85,28 @@ final class Main {
 	 * @internal description
 	 */
 	public static function activate(): void {
-		update_option( 'publish_with_ai_version', RTCAMP_PUBLISH_WITH_AI_VERSION );
+		self::run_migrations();
+		flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+	}
+
+	/**
+	 * Runs schema migrations when the stored plugin version is older than the current one.
+	 */
+	public static function maybe_upgrade(): void {
+		$stored = (string) get_option( 'publish_with_ai_version', '0.0.0' );
+
+		if ( version_compare( $stored, RTCAMP_PUBLISH_WITH_AI_VERSION, '<' ) ) {
+			self::run_migrations();
+		}
+	}
+
+	/**
+	 * Create / update all DB tables and record the current version.
+	 */
+	private static function run_migrations(): void {
 		Modules\MCP\OAuth\Storage\Token_Store::create_table();
 		Modules\MCP\OAuth\Storage\Client_Store::create_table();
-		flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+		update_option( 'publish_with_ai_version', RTCAMP_PUBLISH_WITH_AI_VERSION );
 	}
 
 	/**

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -30,6 +30,7 @@ final class Main {
 		Modules\Settings\Credentials\REST_Controller::class,
 		Modules\Screenshot\Settings::class,
 		Modules\Screenshot\REST_Controller::class,
+		Modules\Screenshot\Preview_Endpoint::class,
 		Modules\MCP\OAuth\OAuth::class,
 		Modules\MCP\Abilities\Abilities::class,
 		Modules\MCP\Server\Server::class,

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -28,6 +28,8 @@ final class Main {
 		Modules\Settings\Menu_Loader::class,
 		Modules\Settings\Connections\REST_Controller::class,
 		Modules\Settings\Credentials\REST_Controller::class,
+		Modules\Screenshot\Settings::class,
+		Modules\Screenshot\REST_Controller::class,
 		Modules\MCP\OAuth\OAuth::class,
 		Modules\MCP\Abilities\Abilities::class,
 		Modules\MCP\Server\Server::class,

--- a/inc/Modules/MCP/Abilities/Abilities.php
+++ b/inc/Modules/MCP/Abilities/Abilities.php
@@ -16,6 +16,7 @@ use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Blocks\Render_Block;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Blocks as Blocks_Category;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Patterns as Patterns_Category;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Posts as Posts_Category;
+use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Preview as Preview_Category;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Patterns\Apply_Pattern_Schema;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Patterns\Get_Pattern;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Patterns\Get_Pattern_Schema;
@@ -32,6 +33,7 @@ use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Search_Posts;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Set_Featured_Image;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Update_Post;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Upload_Media;
+use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Preview\Screenshot_Post;
 
 /**
  * Class - Abilities
@@ -57,6 +59,7 @@ final class Abilities implements Registrable {
 			new Patterns_Category(),
 			new Blocks_Category(),
 			new Posts_Category(),
+			new Preview_Category(),
 		];
 
 		foreach ( $categories as $category ) {
@@ -92,6 +95,7 @@ final class Abilities implements Registrable {
 			new Search_Posts(),
 			new Search_Attachments(),
 			new Upload_Media(),
+			new Screenshot_Post(),
 		];
 
 		foreach ( $abilities as $ability ) {

--- a/inc/Modules/MCP/Abilities/Categories/Preview.php
+++ b/inc/Modules/MCP/Abilities/Categories/Preview.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Preview ability category.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories;
+
+/**
+ * Class - Preview
+ */
+class Preview {
+	public const SLUG = 'rtpwai-preview';
+
+	/**
+	 * Register the category.
+	 */
+	public function register(): void {
+		wp_register_ability_category(
+			self::SLUG,
+			[
+				'label'       => __( 'Preview', 'rtcamp-publish-with-ai' ),
+				'description' => __( 'Capture screenshots of pages and patterns during publishing.', 'rtcamp-publish-with-ai' ),
+			]
+		);
+	}
+}

--- a/inc/Modules/MCP/Abilities/Preview/Screenshot_Post.php
+++ b/inc/Modules/MCP/Abilities/Preview/Screenshot_Post.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Screenshot Post ability.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\MCP\Abilities\Preview
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\MCP\Abilities\Preview;
+
+use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Preview as Preview_Category;
+use rtCamp\Publish_With_AI\Modules\Screenshot\Screenshot_Client;
+use rtCamp\Publish_With_AI\Modules\Screenshot\Settings;
+use rtCamp\Publish_With_AI\Modules\Screenshot\Token_Store;
+
+/**
+ * Class - Screenshot_Post
+ */
+class Screenshot_Post {
+	/**
+	 * Register the ability.
+	 */
+	public function register(): void {
+		wp_register_ability(
+			'rtpwai/screenshot-post',
+			[
+				'label'               => __( 'Screenshot Page or Post', 'rtcamp-publish-with-ai' ),
+				'category'            => Preview_Category::SLUG,
+				'description'         => __( 'Captures a screenshot of a page or post and returns it as an inline image. Requires screenshot provider to be configured in Settings → Screenshots. Returns not_supported when the feature is disabled or misconfigured.', 'rtcamp-publish-with-ai' ),
+				'input_schema'        => [
+					'type'                 => 'object',
+					'required'             => [ 'post_id' ],
+					'properties'           => [
+						'post_id'  => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => 'ID of the post or page to screenshot.',
+						],
+						'selector' => [
+							'type'        => 'string',
+							'description' => 'CSS selector to crop the screenshot to. Defaults to "main". Use "body" for the full viewport.',
+							'default'     => 'main',
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'edit_posts' );
+				},
+				'execute_callback'    => static function ( array $input ): array|\WP_Error {
+					if ( ! Settings::is_configured() ) {
+						return new \WP_Error(
+							'not_supported',
+							__( 'Screenshot feature is not configured. Enable it under Settings → Screenshots and provide an API key if required.', 'rtcamp-publish-with-ai' )
+						);
+					}
+
+					$post_id  = (int) ( $input['post_id'] ?? 0 );
+					$selector = sanitize_text_field( (string) ( $input['selector'] ?? 'main' ) );
+
+					if ( $post_id < 1 || ! get_post( $post_id ) ) {
+						return new \WP_Error( 'invalid_post', __( 'Post not found.', 'rtcamp-publish-with-ai' ) );
+					}
+
+					$user_id = get_current_user_id();
+
+					if ( 0 === $user_id ) {
+						return new \WP_Error( 'not_authenticated', __( 'No authenticated user for preview.', 'rtcamp-publish-with-ai' ) );
+					}
+
+					$token       = Token_Store::create( $post_id, $user_id );
+					$preview_url = rest_url( 'rtpwai/v1/preview' ) . '?token=' . rawurlencode( $token );
+
+					$image = Screenshot_Client::capture( $preview_url, $selector );
+
+					if ( is_wp_error( $image ) ) {
+						return $image;
+					}
+
+					return [
+						'type'     => 'image',
+						'results'  => $image,
+						'mimeType' => 'image/png',
+					];
+				},
+				'meta'                => [
+					'show_in_rest' => true,
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => false,
+					],
+					'mcp'          => [
+						'public' => true,
+					],
+				],
+			]
+		);
+	}
+}

--- a/inc/Modules/MCP/Abilities/Preview/Screenshot_Post.php
+++ b/inc/Modules/MCP/Abilities/Preview/Screenshot_Post.php
@@ -10,7 +10,9 @@ declare( strict_types = 1 );
 namespace rtCamp\Publish_With_AI\Modules\MCP\Abilities\Preview;
 
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Preview as Preview_Category;
+use rtCamp\Publish_With_AI\Modules\Screenshot\Preview_Endpoint;
 use rtCamp\Publish_With_AI\Modules\Screenshot\Screenshot_Client;
+use rtCamp\Publish_With_AI\Modules\Screenshot\Screenshot_Image_Endpoint;
 use rtCamp\Publish_With_AI\Modules\Screenshot\Settings;
 use rtCamp\Publish_With_AI\Modules\Screenshot\Token_Store;
 
@@ -27,7 +29,7 @@ class Screenshot_Post {
 			[
 				'label'               => __( 'Screenshot Page or Post', 'rtcamp-publish-with-ai' ),
 				'category'            => Preview_Category::SLUG,
-				'description'         => __( 'Captures a screenshot of a page or post and returns it as an inline image. Requires screenshot provider to be configured in Settings → Screenshots. Returns not_supported when the feature is disabled or misconfigured.', 'rtcamp-publish-with-ai' ),
+				'description'         => __( 'Captures a screenshot of a page or post. Returns a screenshot_url — embed it in your response as ![Screenshot](screenshot_url) so the user sees it inline. Requires screenshot provider to be configured in Settings → Screenshots. Returns not_supported when the feature is disabled or misconfigured.', 'rtcamp-publish-with-ai' ),
 				'input_schema'        => [
 					'type'                 => 'object',
 					'required'             => [ 'post_id' ],
@@ -69,7 +71,18 @@ class Screenshot_Post {
 						return new \WP_Error( 'not_authenticated', __( 'No authenticated user for preview.', 'rtcamp-publish-with-ai' ) );
 					}
 
-					$token       = Token_Store::create( $post_id, $user_id );
+					$token = Token_Store::create( $post_id, $user_id );
+
+					// Pre-render the HTML here so the preview endpoint can serve it
+					// instantly when Microlink visits — no loopback inside Microlink's timeout.
+					$html = Preview_Endpoint::fetch_page_html( $post_id, $user_id );
+
+					if ( is_wp_error( $html ) ) {
+						return $html;
+					}
+
+					set_transient( Preview_Endpoint::HTML_PREFIX . $token, $html, 15 * MINUTE_IN_SECONDS );
+
 					$preview_url = rest_url( 'rtpwai/v1/preview' ) . '?token=' . rawurlencode( $token );
 
 					$image = Screenshot_Client::capture( $preview_url, $selector );
@@ -78,11 +91,16 @@ class Screenshot_Post {
 						return $image;
 					}
 
-					return [
-						'type'     => 'image',
-						'results'  => $image,
-						'mimeType' => 'image/png',
-					];
+					$image_token = wp_generate_uuid4();
+					set_transient(
+						Screenshot_Image_Endpoint::TRANSIENT_PREFIX . $image_token,
+						base64_encode( $image ),
+						Screenshot_Image_Endpoint::TTL
+					);
+
+					$screenshot_url = rest_url( 'rtpwai/v1/screenshot-image' ) . '?token=' . rawurlencode( $image_token );
+
+					return [ 'screenshot_url' => $screenshot_url ];
 				},
 				'meta'                => [
 					'show_in_rest' => true,

--- a/inc/Modules/Screenshot/Preview_Endpoint.php
+++ b/inc/Modules/Screenshot/Preview_Endpoint.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Token-gated preview endpoint.
+ *
+ * Validates a single-use preview token and proxies the fully-rendered
+ * WordPress page HTML back to the caller (typically a screenshot API).
+ *
+ * Route: GET /wp-json/rtpwai/v1/preview?token={token}
+ *
+ * The endpoint is intentionally public (no WordPress authentication required)
+ * because the token itself provides the security: it is a random UUID v4,
+ * single-use, and expires after 10 minutes.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\Screenshot
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\Screenshot;
+
+use rtCamp\Publish_With_AI\Framework\Contracts\Interfaces\Registrable;
+
+/**
+ * Class - Preview_Endpoint
+ */
+class Preview_Endpoint implements Registrable {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks(): void {
+		add_action( 'rest_api_init', [ $this, 'register_route' ] );
+	}
+
+	/**
+	 * Register the preview REST route.
+	 */
+	public function register_route(): void {
+		register_rest_route(
+			'rtpwai/v1',
+			'/preview',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'serve' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
+					'token' => [
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Validate the token and serve the rendered page HTML.
+	 *
+	 * Exits directly rather than returning a WP_REST_Response so that raw HTML
+	 * is sent without JSON wrapping.
+	 *
+	 * @param \WP_REST_Request $request Incoming request.
+	 */
+	public function serve( \WP_REST_Request $request ): never {
+		$token = sanitize_text_field( (string) $request->get_param( 'token' ) );
+
+		if ( '' === $token ) {
+			status_header( 400 );
+			exit;
+		}
+
+		$data = Token_Store::consume( $token );
+
+		if ( null === $data ) {
+			status_header( 403 );
+			exit;
+		}
+
+		$html = $this->fetch_page_html( $data['post_id'], $data['user_id'] );
+
+		if ( is_wp_error( $html ) ) {
+			status_header( 500 );
+			exit;
+		}
+
+		header( 'Content-Type: text/html; charset=utf-8' );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $html;
+		exit;
+	}
+
+	/**
+	 * Fetch the rendered WordPress preview HTML via an authenticated loopback request.
+	 *
+	 * Switches to the token owner's user so that the preview nonce is valid, then
+	 * makes an internal HTTP request with short-lived auth cookies.
+	 *
+	 * @param int $post_id Post to preview.
+	 * @param int $user_id User whose session renders the preview.
+	 *
+	 * @return string|\WP_Error Rendered HTML or error.
+	 */
+	private function fetch_page_html( int $post_id, int $user_id ): string|\WP_Error {
+		// Switch user so get_preview_post_link() generates a nonce for the right user.
+		wp_set_current_user( $user_id );
+
+		$preview_url = get_preview_post_link( $post_id );
+
+		if ( ! $preview_url ) {
+			return new \WP_Error( 'no_preview_url', __( 'Could not generate preview URL.', 'rtcamp-publish-with-ai' ) );
+		}
+
+		$expiry  = time() + MINUTE_IN_SECONDS;
+		$cookies = [
+			new \WP_Http_Cookie(
+				[
+					'name'  => AUTH_COOKIE,
+					'value' => wp_generate_auth_cookie( $user_id, $expiry, 'auth' ),
+				]
+			),
+			new \WP_Http_Cookie(
+				[
+					'name'  => SECURE_AUTH_COOKIE,
+					'value' => wp_generate_auth_cookie( $user_id, $expiry, 'secure_auth' ),
+				]
+			),
+			new \WP_Http_Cookie(
+				[
+					'name'  => LOGGED_IN_COOKIE,
+					'value' => wp_generate_auth_cookie( $user_id, $expiry, 'logged_in' ),
+				]
+			),
+		];
+
+		$response = wp_remote_get( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+			$preview_url,
+			[
+				'cookies'     => $cookies,
+				'timeout'     => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+				// SSL verification is disabled for the server-to-itself loopback request.
+				'sslverify'   => false,
+				'redirection' => 5,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $code ) {
+			return new \WP_Error(
+				'preview_failed',
+				sprintf(
+					/* translators: %d: HTTP status code */
+					__( 'Preview request returned HTTP %d.', 'rtcamp-publish-with-ai' ),
+					$code
+				)
+			);
+		}
+
+		return wp_remote_retrieve_body( $response );
+	}
+}

--- a/inc/Modules/Screenshot/Preview_Endpoint.php
+++ b/inc/Modules/Screenshot/Preview_Endpoint.php
@@ -25,6 +25,11 @@ use rtCamp\Publish_With_AI\Framework\Contracts\Interfaces\Registrable;
  */
 class Preview_Endpoint implements Registrable {
 	/**
+	 * Transient key prefix for pre-rendered preview HTML.
+	 */
+	public const HTML_PREFIX = 'rtpwai_preview_html_';
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function register_hooks(): void {
@@ -76,7 +81,12 @@ class Preview_Endpoint implements Registrable {
 			exit;
 		}
 
-		$html = $this->fetch_page_html( $data['post_id'], $data['user_id'] );
+		// Use pre-rendered HTML cached by the MCP tool before Microlink was called.
+		// Falls back to a live loopback request if the cache is missing.
+		$cached = get_transient( self::HTML_PREFIX . $token );
+		delete_transient( self::HTML_PREFIX . $token );
+
+		$html = false !== $cached ? $cached : self::fetch_page_html( $data['post_id'], $data['user_id'] );
 
 		if ( is_wp_error( $html ) ) {
 			status_header( 500 );
@@ -100,7 +110,7 @@ class Preview_Endpoint implements Registrable {
 	 *
 	 * @return string|\WP_Error Rendered HTML or error.
 	 */
-	private function fetch_page_html( int $post_id, int $user_id ): string|\WP_Error {
+	public static function fetch_page_html( int $post_id, int $user_id ): string|\WP_Error {
 		// Switch user so get_preview_post_link() generates a nonce for the right user.
 		wp_set_current_user( $user_id );
 

--- a/inc/Modules/Screenshot/Providers/Microlink_Provider.php
+++ b/inc/Modules/Screenshot/Providers/Microlink_Provider.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Screenshot provider — Microlink.
+ *
+ * API docs: https://microlink.io/docs/api/parameters/screenshot
+ *
+ * @package rtCamp\Publish_With_AI\Modules\Screenshot\Providers
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\Screenshot\Providers;
+
+/**
+ * Class - Microlink_Provider
+ */
+class Microlink_Provider {
+	/**
+	 * Microlink API base URL.
+	 */
+	private const API_URL = 'https://api.microlink.io';
+
+	/**
+	 * Optional Microlink API key.
+	 *
+	 * @var string
+	 */
+	private string $api_key;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $api_key Optional Microlink API key (unlocks higher rate limits).
+	 */
+	public function __construct( string $api_key ) {
+		$this->api_key = $api_key;
+	}
+
+	/**
+	 * Capture a screenshot of the given URL and return raw PNG bytes.
+	 *
+	 * @param string $url      URL to screenshot.
+	 * @param string $selector CSS selector to crop to (e.g. 'main').
+	 *
+	 * @return string|\WP_Error Raw binary PNG on success, WP_Error on failure.
+	 */
+	public function capture( string $url, string $selector ): string|\WP_Error {
+		$query = http_build_query(
+			[
+				'url'                        => $url,
+				'screenshot'                 => 'true',
+				'element'                    => $selector,
+				'viewport.width'             => '1440',
+				'viewport.height'            => '900',
+				'viewport.deviceScaleFactor' => '1',
+			]
+		);
+
+		$headers = [ 'Accept' => 'application/json' ];
+
+		if ( '' !== $this->api_key ) {
+			$headers['x-api-key'] = $this->api_key;
+		}
+
+		$response = wp_remote_get( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+			self::API_URL . '?' . $query,
+			[
+				'headers' => $headers,
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 200 !== $code || empty( $body['data']['screenshot']['url'] ) ) {
+			$message = $body['message'] ?? sprintf(
+				/* translators: %d: HTTP status code */
+				__( 'Microlink API returned HTTP %d.', 'rtcamp-publish-with-ai' ),
+				$code
+			);
+			return new \WP_Error( 'microlink_failed', $message );
+		}
+
+		$image_response = wp_remote_get( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+			$body['data']['screenshot']['url'],
+			[ 'timeout' => 30 ] // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+		);
+
+		if ( is_wp_error( $image_response ) ) {
+			return $image_response;
+		}
+
+		return wp_remote_retrieve_body( $image_response );
+	}
+}

--- a/inc/Modules/Screenshot/Providers/Microlink_Provider.php
+++ b/inc/Modules/Screenshot/Providers/Microlink_Provider.php
@@ -45,16 +45,20 @@ class Microlink_Provider {
 	 * @return string|\WP_Error Raw binary PNG on success, WP_Error on failure.
 	 */
 	public function capture( string $url, string $selector ): string|\WP_Error {
-		$query = http_build_query(
-			[
-				'url'                        => $url,
-				'screenshot'                 => 'true',
-				'element'                    => $selector,
-				'viewport.width'             => '1440',
-				'viewport.height'            => '900',
-				'viewport.deviceScaleFactor' => '1',
-			]
-		);
+		$params = [
+			'url'                        => $url,
+			'screenshot'                 => 'true',
+			'viewport.width'             => '1440',
+			'viewport.height'            => '900',
+			'viewport.deviceScaleFactor' => '1',
+		];
+
+		// 'element' is a Microlink Pro feature — omit on the free tier.
+		if ( '' !== $this->api_key ) {
+			$params['element'] = $selector;
+		}
+
+		$query = http_build_query( $params );
 
 		$headers = [ 'Accept' => 'application/json' ];
 
@@ -83,7 +87,7 @@ class Microlink_Provider {
 				__( 'Microlink API returned HTTP %d.', 'rtcamp-publish-with-ai' ),
 				$code
 			);
-			return new \WP_Error( 'microlink_failed', $message );
+			return new \WP_Error( 'microlink_failed', $message, $body['errors'] ?? null );
 		}
 
 		$image_response = wp_remote_get( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get

--- a/inc/Modules/Screenshot/Providers/ScreenshotOne_Provider.php
+++ b/inc/Modules/Screenshot/Providers/ScreenshotOne_Provider.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Screenshot provider — ScreenshotOne.
+ *
+ * API docs: https://screenshotone.com/docs/
+ *
+ * @package rtCamp\Publish_With_AI\Modules\Screenshot\Providers
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\Screenshot\Providers;
+
+/**
+ * Class - ScreenshotOne_Provider
+ */
+class ScreenshotOne_Provider {
+	/**
+	 * ScreenshotOne API endpoint.
+	 */
+	private const API_URL = 'https://api.screenshotone.com/take';
+
+	/**
+	 * ScreenshotOne access key.
+	 *
+	 * @var string
+	 */
+	private string $api_key;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $api_key ScreenshotOne access key.
+	 */
+	public function __construct( string $api_key ) {
+		$this->api_key = $api_key;
+	}
+
+	/**
+	 * Capture a screenshot of the given URL and return raw PNG bytes.
+	 *
+	 * @param string $url      URL to screenshot.
+	 * @param string $selector CSS selector to crop to (e.g. 'main').
+	 *
+	 * @return string|\WP_Error Raw binary PNG on success, WP_Error on failure.
+	 */
+	public function capture( string $url, string $selector ): string|\WP_Error {
+		$query = http_build_query(
+			[
+				'access_key'      => $this->api_key,
+				'url'             => $url,
+				'format'          => 'png',
+				'selector'        => $selector,
+				'hide_selectors'  => '#wpadminbar,header,footer,nav',
+				'viewport_width'  => '1440',
+				'viewport_height' => '900',
+				'image_quality'   => '90',
+			]
+		);
+
+		$response = wp_remote_get( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+			self::API_URL . '?' . $query,
+			[ 'timeout' => 60 ] // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code         = wp_remote_retrieve_response_code( $response );
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+
+		if ( 200 !== $code || false === strpos( (string) $content_type, 'image/' ) ) {
+			$body = wp_remote_retrieve_body( $response );
+			$data = json_decode( $body, true );
+
+			$message = is_array( $data ) && ! empty( $data['error_message'] )
+				? $data['error_message']
+				: sprintf(
+					/* translators: %d: HTTP status code */
+					__( 'ScreenshotOne API returned HTTP %d.', 'rtcamp-publish-with-ai' ),
+					$code
+				);
+
+			return new \WP_Error( 'screenshotone_failed', $message );
+		}
+
+		return wp_remote_retrieve_body( $response );
+	}
+}

--- a/inc/Modules/Screenshot/REST_Controller.php
+++ b/inc/Modules/Screenshot/REST_Controller.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * REST API endpoint for reading and updating screenshot settings.
+ *
+ * Routes (both require manage_options):
+ *   GET /wp-json/rtpwai/v1/screenshot-settings
+ *   PUT /wp-json/rtpwai/v1/screenshot-settings
+ *
+ * @package rtCamp\Publish_With_AI\Modules\Screenshot
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\Screenshot;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use rtCamp\Publish_With_AI\Framework\Contracts\Abstracts\Abstract_REST_Controller;
+
+/**
+ * Class - REST_Controller
+ */
+class REST_Controller extends Abstract_REST_Controller {
+	/**
+	 * {@inheritDoc}
+	 */
+	protected $rest_base = 'screenshot-settings';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_routes(): void {
+		/** @var non-falsy-string $namespace */
+		$namespace = $this->namespace . $this->version;
+
+		register_rest_route(
+			$namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_settings' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+				],
+				[
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'update_settings' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => [
+						'enabled'  => [
+							'type'     => 'boolean',
+							'required' => true,
+						],
+						'provider' => [
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'api_key'  => [
+							'type'              => 'string',
+							'required'          => false,
+							'default'           => '',
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * GET /screenshot-settings
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 */
+	public function get_settings( WP_REST_Request $request ): WP_REST_Response { // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+		return new WP_REST_Response( $this->current_settings(), 200 );
+	}
+
+	/**
+	 * PUT /screenshot-settings
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function update_settings( WP_REST_Request $request ) {
+		$provider_id = sanitize_text_field( (string) $request->get_param( 'provider' ) );
+
+		if ( null === Settings::find_provider( $provider_id ) ) {
+			return new \WP_Error(
+				'invalid_provider',
+				__( 'Unknown screenshot provider.', 'rtcamp-publish-with-ai' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		update_option( Settings::OPTION_ENABLED, (bool) $request->get_param( 'enabled' ), false );
+		update_option( Settings::OPTION_PROVIDER, $provider_id, false );
+
+		$api_key = sanitize_text_field( (string) $request->get_param( 'api_key' ) );
+
+		if ( '' !== $api_key ) {
+			update_option( Settings::OPTION_API_KEY, $api_key, false );
+		}
+
+		return new WP_REST_Response( $this->current_settings(), 200 );
+	}
+
+	/**
+	 * Only site admins may manage screenshot settings.
+	 */
+	public function permissions_check(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Build the settings payload returned to the client.
+	 *
+	 * The raw API key is never returned — only a boolean indicating one is stored.
+	 *
+	 * @return array{enabled: bool, provider: string, has_api_key: bool, providers: array<int, mixed>}
+	 */
+	private function current_settings(): array {
+		return [
+			'enabled'     => Settings::is_enabled(),
+			'provider'    => Settings::get_provider(),
+			'has_api_key' => '' !== Settings::get_api_key(),
+			'providers'   => Settings::get_providers(),
+		];
+	}
+}

--- a/inc/Modules/Screenshot/Screenshot_Client.php
+++ b/inc/Modules/Screenshot/Screenshot_Client.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Screenshot client — dispatches to the configured provider.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\Screenshot
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\Screenshot;
+
+use rtCamp\Publish_With_AI\Modules\Screenshot\Providers\Microlink_Provider;
+use rtCamp\Publish_With_AI\Modules\Screenshot\Providers\ScreenshotOne_Provider;
+
+/**
+ * Class - Screenshot_Client
+ */
+final class Screenshot_Client {
+	/**
+	 * Capture a screenshot of the given URL using the active provider.
+	 *
+	 * Returns raw binary PNG data on success. The caller is responsible for
+	 * confirming that Settings::is_configured() before calling this method.
+	 *
+	 * @param string $url      Fully-qualified URL to screenshot. Must be publicly reachable.
+	 * @param string $selector CSS selector to crop to. Defaults to 'main'.
+	 *
+	 * @return string|\WP_Error Raw binary PNG, or WP_Error on failure.
+	 */
+	public static function capture( string $url, string $selector = 'main' ): string|\WP_Error {
+		$provider_id = Settings::get_provider();
+		$api_key     = Settings::get_api_key();
+
+		switch ( $provider_id ) {
+			case 'microlink':
+				return ( new Microlink_Provider( $api_key ) )->capture( $url, $selector );
+
+			case 'screenshotone':
+				return ( new ScreenshotOne_Provider( $api_key ) )->capture( $url, $selector );
+
+			default:
+				/**
+				 * Fires when a custom screenshot provider ID is encountered.
+				 *
+				 * Third-party providers registered via publish_with_ai_screenshot_providers
+				 * can hook here to handle their own provider IDs.
+				 *
+				 * @param string $url         URL to screenshot.
+				 * @param string $selector    CSS selector.
+				 * @param string $api_key     Configured API key.
+				 * @param string $provider_id Active provider ID.
+				 */
+				$result = apply_filters( 'publish_with_ai_screenshot_capture', null, $url, $selector, $api_key, $provider_id );
+
+				if ( is_string( $result ) && '' !== $result ) {
+					return $result;
+				}
+
+				return new \WP_Error(
+					'unknown_provider',
+					sprintf(
+						/* translators: %s: provider ID */
+						__( 'Unknown screenshot provider: %s', 'rtcamp-publish-with-ai' ),
+						$provider_id
+					)
+				);
+		}
+	}
+}

--- a/inc/Modules/Screenshot/Screenshot_Image_Endpoint.php
+++ b/inc/Modules/Screenshot/Screenshot_Image_Endpoint.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Ephemeral screenshot image endpoint.
+ *
+ * Serves a short-lived screenshot PNG captured by the MCP screenshot tool.
+ * The image binary is stored in a transient; this endpoint reads and returns it
+ * so that external clients (e.g. Claude) can display it via a public URL.
+ *
+ * Route: GET /wp-json/rtpwai/v1/screenshot-image?token={token}
+ *
+ * @package rtCamp\Publish_With_AI\Modules\Screenshot
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\Screenshot;
+
+use rtCamp\Publish_With_AI\Framework\Contracts\Interfaces\Registrable;
+
+/**
+ * Class - Screenshot_Image_Endpoint
+ */
+class Screenshot_Image_Endpoint implements Registrable {
+	/**
+	 * Transient key prefix for screenshot image binaries.
+	 */
+	public const TRANSIENT_PREFIX = 'rtpwai_screenshot_img_';
+
+	/**
+	 * How long to keep the image available (1 hour).
+	 */
+	public const TTL = 3600;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks(): void {
+		add_action( 'rest_api_init', [ $this, 'register_route' ] );
+	}
+
+	/**
+	 * Register the screenshot image REST route.
+	 */
+	public function register_route(): void {
+		register_rest_route(
+			'rtpwai/v1',
+			'/screenshot-image',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'serve' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
+					'token' => [
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Serve the screenshot image binary from the transient store.
+	 *
+	 * @param \WP_REST_Request $request Incoming request.
+	 */
+	public function serve( \WP_REST_Request $request ): never {
+		$token = sanitize_key( (string) $request->get_param( 'token' ) );
+
+		if ( '' === $token ) {
+			status_header( 400 );
+			exit;
+		}
+
+		$image = get_transient( self::TRANSIENT_PREFIX . $token );
+
+		if ( false === $image || ! is_string( $image ) ) {
+			status_header( 404 );
+			exit;
+		}
+
+		header( 'Content-Type: image/png' );
+		header( 'Cache-Control: private, max-age=' . self::TTL );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo base64_decode( $image );
+		exit;
+	}
+}

--- a/inc/Modules/Screenshot/Settings.php
+++ b/inc/Modules/Screenshot/Settings.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Screenshot settings — option registration and static accessors.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\Screenshot
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\Screenshot;
+
+use rtCamp\Publish_With_AI\Framework\Contracts\Interfaces\Registrable;
+
+/**
+ * Class - Settings
+ */
+final class Settings implements Registrable {
+	/**
+	 * Option keys.
+	 */
+	public const OPTION_ENABLED  = 'rtpwai_screenshot_enabled';
+	public const OPTION_PROVIDER = 'rtpwai_screenshot_provider';
+	public const OPTION_API_KEY  = 'rtpwai_screenshot_api_key';
+
+	/**
+	 * Built-in providers.
+	 *
+	 * @var array<int, array{id: string, label: string, requires_key: bool, key_label: string}>
+	 */
+	private const BUILT_IN_PROVIDERS = [
+		[
+			'id'           => 'microlink',
+			'label'        => 'Microlink',
+			'requires_key' => false,
+			'key_label'    => 'API Key (optional — unlocks higher limits)',
+		],
+		[
+			'id'           => 'screenshotone',
+			'label'        => 'ScreenshotOne',
+			'requires_key' => true,
+			'key_label'    => 'Access Key',
+		],
+	];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks(): void {
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
+		add_action( 'rest_api_init', [ $this, 'register_settings' ] );
+	}
+
+	/**
+	 * Register plugin options with WordPress.
+	 */
+	public function register_settings(): void {
+		register_setting(
+			'rtpwai_screenshot_group',
+			self::OPTION_ENABLED,
+			[
+				'type'              => 'boolean',
+				'default'           => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'show_in_rest'      => false,
+			]
+		);
+
+		register_setting(
+			'rtpwai_screenshot_group',
+			self::OPTION_PROVIDER,
+			[
+				'type'              => 'string',
+				'default'           => 'microlink',
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => false,
+			]
+		);
+
+		register_setting(
+			'rtpwai_screenshot_group',
+			self::OPTION_API_KEY,
+			[
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => false,
+			]
+		);
+	}
+
+	/**
+	 * Whether the screenshot feature is enabled.
+	 */
+	public static function is_enabled(): bool {
+		return (bool) get_option( self::OPTION_ENABLED, false );
+	}
+
+	/**
+	 * Active provider ID.
+	 */
+	public static function get_provider(): string {
+		return (string) get_option( self::OPTION_PROVIDER, 'microlink' );
+	}
+
+	/**
+	 * Stored API key (plaintext).
+	 */
+	public static function get_api_key(): string {
+		return (string) get_option( self::OPTION_API_KEY, '' );
+	}
+
+	/**
+	 * Whether the feature is enabled and all required settings are present.
+	 */
+	public static function is_configured(): bool {
+		if ( ! self::is_enabled() ) {
+			return false;
+		}
+
+		$provider = self::find_provider( self::get_provider() );
+
+		if ( null === $provider ) {
+			return false;
+		}
+
+		return ! $provider['requires_key'] || '' !== self::get_api_key();
+	}
+
+	/**
+	 * All registered providers (built-in + filter).
+	 *
+	 * @return array<int, array{id: string, label: string, requires_key: bool, key_label: string}>
+	 */
+	public static function get_providers(): array {
+		/**
+		 * Filters the list of available screenshot providers.
+		 *
+		 * Each provider must be an associative array with keys:
+		 *   id (string), label (string), requires_key (bool), key_label (string).
+		 *
+		 * @param array<int, array{id: string, label: string, requires_key: bool, key_label: string}> $providers Built-in providers.
+		 */
+		return (array) apply_filters( 'publish_with_ai_screenshot_providers', self::BUILT_IN_PROVIDERS );
+	}
+
+	/**
+	 * Find a provider by ID, or null if not found.
+	 *
+	 * @param string $id Provider ID.
+	 *
+	 * @return array{id: string, label: string, requires_key: bool, key_label: string}|null
+	 */
+	public static function find_provider( string $id ): ?array {
+		foreach ( self::get_providers() as $provider ) {
+			if ( $provider['id'] === $id ) {
+				return $provider;
+			}
+		}
+
+		return null;
+	}
+}

--- a/inc/Modules/Screenshot/Token_Store.php
+++ b/inc/Modules/Screenshot/Token_Store.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Single-use preview token management backed by WordPress transients.
+ *
+ * Tokens are created by the MCP ability and consumed exactly once by the
+ * Preview_Endpoint. A 10-minute TTL acts as a fallback if the endpoint is
+ * never called.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\Screenshot
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\Screenshot;
+
+/**
+ * Class - Token_Store
+ */
+final class Token_Store {
+	/**
+	 * Transient key prefix.
+	 */
+	private const PREFIX = 'rtpwai_preview_';
+
+	/**
+	 * Token TTL in seconds (10 minutes).
+	 */
+	private const TTL = 600;
+
+	/**
+	 * Create a new single-use preview token for the given post and user.
+	 *
+	 * @param int $post_id Post ID to preview.
+	 * @param int $user_id User ID whose session will render the preview.
+	 *
+	 * @return string The generated token (UUID v4).
+	 */
+	public static function create( int $post_id, int $user_id ): string {
+		$token = wp_generate_uuid4();
+
+		set_transient(
+			self::PREFIX . $token,
+			[
+				'post_id' => $post_id,
+				'user_id' => $user_id,
+			],
+			self::TTL
+		);
+
+		return $token;
+	}
+
+	/**
+	 * Consume a token — validates it and deletes it atomically.
+	 *
+	 * Returns the stored payload on success, null if the token does not exist
+	 * or has already been consumed/expired.
+	 *
+	 * @param string $token Token to consume.
+	 *
+	 * @return array{post_id: int, user_id: int}|null
+	 */
+	public static function consume( string $token ): ?array {
+		$key  = self::PREFIX . sanitize_key( $token );
+		$data = get_transient( $key );
+
+		if ( ! is_array( $data ) || empty( $data['post_id'] ) || empty( $data['user_id'] ) ) {
+			return null;
+		}
+
+		delete_transient( $key );
+
+		return [
+			'post_id' => (int) $data['post_id'],
+			'user_id' => (int) $data['user_id'],
+		];
+	}
+}

--- a/inc/Modules/Settings/Menu_Loader.php
+++ b/inc/Modules/Settings/Menu_Loader.php
@@ -18,6 +18,7 @@ use rtCamp\Publish_With_AI\Framework\Contracts\Interfaces\Registrable;
 use rtCamp\Publish_With_AI\Modules\Settings\Pages\Connections_Page;
 use rtCamp\Publish_With_AI\Modules\Settings\Pages\Credentials_Page;
 use rtCamp\Publish_With_AI\Modules\Settings\Pages\Guide_Page;
+use rtCamp\Publish_With_AI\Modules\Settings\Pages\Settings_Page;
 
 /**
  * Class - Menu_Loader
@@ -33,6 +34,7 @@ final class Menu_Loader implements Registrable {
 		Guide_Page::class,
 		Connections_Page::class,
 		Credentials_Page::class,
+		Settings_Page::class,
 	];
 
 	/**

--- a/inc/Modules/Settings/Pages/Screenshot_Page.php
+++ b/inc/Modules/Settings/Pages/Screenshot_Page.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Admin page definition for the Screenshot settings sub-page.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\Settings\Pages
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\Settings\Pages;
+
+use rtCamp\Publish_With_AI\Core\Assets;
+use rtCamp\Publish_With_AI\Core\Templates;
+use rtCamp\Publish_With_AI\Framework\Contracts\Abstracts\Abstract_Admin_Page;
+
+/**
+ * Class - Screenshot_Page
+ */
+class Screenshot_Page extends Abstract_Admin_Page {
+	public const SLUG = 'rtcamp-publish-with-ai-screenshot';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register(): string|false {
+		return add_submenu_page(
+			Guide_Page::SLUG,
+			__( 'Screenshots', 'rtcamp-publish-with-ai' ),
+			__( 'Screenshots', 'rtcamp-publish-with-ai' ),
+			'manage_options',
+			self::SLUG,
+			[ $this, 'render' ]
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function enqueue( array $localized_data ): void {
+		wp_localize_script( Assets::ADMIN_SCREENSHOT_HANDLE, 'rtPublishWithAIAdmin', $localized_data );
+		wp_enqueue_script( Assets::ADMIN_SCREENSHOT_HANDLE );
+		wp_enqueue_style( Assets::ADMIN_SCREENSHOT_HANDLE );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render(): void {
+		Templates::get_template_part( 'screenshot-screen' );
+	}
+}

--- a/inc/Modules/Settings/Pages/Settings_Page.php
+++ b/inc/Modules/Settings/Pages/Settings_Page.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Admin page definition for the plugin Settings sub-page.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\Settings\Pages
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\Settings\Pages;
+
+use rtCamp\Publish_With_AI\Core\Assets;
+use rtCamp\Publish_With_AI\Core\Templates;
+use rtCamp\Publish_With_AI\Framework\Contracts\Abstracts\Abstract_Admin_Page;
+
+/**
+ * Class - Settings_Page
+ */
+class Settings_Page extends Abstract_Admin_Page {
+	public const SLUG = 'rtcamp-publish-with-ai-settings';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register(): string|false {
+		return add_submenu_page(
+			Guide_Page::SLUG,
+			__( 'Settings', 'rtcamp-publish-with-ai' ),
+			__( 'Settings', 'rtcamp-publish-with-ai' ),
+			'manage_options',
+			self::SLUG,
+			[ $this, 'render' ]
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function enqueue( array $localized_data ): void {
+		wp_localize_script( Assets::ADMIN_SETTINGS_HANDLE, 'rtPublishWithAIAdmin', $localized_data );
+		wp_enqueue_script( Assets::ADMIN_SETTINGS_HANDLE );
+		wp_enqueue_style( Assets::ADMIN_SETTINGS_HANDLE );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render(): void {
+		Templates::get_template_part( 'settings-screen' );
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,7 +236,6 @@
 			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.7",
 				"@babel/generator": "^7.29.7",
@@ -2313,7 +2312,6 @@
 			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
 			}
@@ -2427,7 +2425,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2476,7 +2473,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2510,8 +2506,7 @@
 			"resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
 			"integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@date-fns/utc": {
 			"version": "2.1.1",
@@ -2539,6 +2534,29 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/JounQin"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -2637,7 +2655,6 @@
 			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -2833,6 +2850,7 @@
 			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
@@ -2847,7 +2865,8 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -2855,6 +2874,7 @@
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2866,6 +2886,7 @@
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -2879,6 +2900,7 @@
 			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/core": "^0.17.0"
 			},
@@ -2892,6 +2914,7 @@
 			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
@@ -2918,6 +2941,7 @@
 			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.14.0",
 				"debug": "^4.3.2",
@@ -2942,6 +2966,7 @@
 			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2958,14 +2983,16 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
-			"license": "Python-2.0"
+			"license": "Python-2.0",
+			"peer": true
 		},
 		"node_modules/@eslint/eslintrc/node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -2973,6 +3000,7 @@
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2984,6 +3012,7 @@
 			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2997,6 +3026,7 @@
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -3007,6 +3037,7 @@
 			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -3019,7 +3050,8 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
 			"version": "3.1.5",
@@ -3027,6 +3059,7 @@
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -3040,6 +3073,7 @@
 			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -3053,6 +3087,7 @@
 			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -3063,6 +3098,7 @@
 			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/core": "^0.17.0",
 				"levn": "^0.4.1"
@@ -3077,6 +3113,7 @@
 			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
@@ -5200,7 +5237,6 @@
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -5576,7 +5612,6 @@
 			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -5600,7 +5635,6 @@
 			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			},
@@ -5614,7 +5648,6 @@
 			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
@@ -6097,7 +6130,6 @@
 			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/semantic-conventions": "1.28.0"
@@ -6125,7 +6157,6 @@
 			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/resources": "1.30.1",
@@ -6154,7 +6185,6 @@
 			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -6983,7 +7013,6 @@
 			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"playwright": "1.60.0"
 			},
@@ -7527,7 +7556,6 @@
 			"integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.21.3",
 				"@svgr/babel-preset": "8.1.0",
@@ -8159,7 +8187,8 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/aws-lambda": {
 			"version": "8.10.161",
@@ -8520,7 +8549,6 @@
 			"integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -8588,7 +8616,6 @@
 			"integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -8600,7 +8627,6 @@
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
@@ -8887,7 +8913,6 @@
 			"integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
 				"@typescript-eslint/scope-manager": "8.60.0",
@@ -11352,7 +11377,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -11446,7 +11470,6 @@
 			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -12546,7 +12569,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -13809,7 +13831,6 @@
 			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mdn-data": "2.27.1",
 				"source-map-js": "^1.2.1"
@@ -14092,7 +14113,6 @@
 			"integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/kossnocorp"
@@ -14439,8 +14459,7 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
 			"integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
 			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
@@ -14532,7 +14551,8 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
@@ -15177,7 +15197,6 @@
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -15328,7 +15347,6 @@
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -15748,6 +15766,7 @@
 			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
@@ -15761,6 +15780,7 @@
 			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -15777,7 +15797,8 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -15785,6 +15806,7 @@
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -15796,6 +15818,7 @@
 			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -15813,6 +15836,7 @@
 			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -15826,6 +15850,7 @@
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -15843,6 +15868,7 @@
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -15852,7 +15878,8 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/eslint/node_modules/locate-path": {
 			"version": "6.0.0",
@@ -15860,6 +15887,7 @@
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -15876,6 +15904,7 @@
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -15889,6 +15918,7 @@
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -18985,7 +19015,6 @@
 			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jest/core": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -20253,7 +20282,6 @@
 			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssstyle": "^4.2.1",
 				"data-urls": "^5.0.0",
@@ -20879,8 +20907,7 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
 			"integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
 			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
 			"version": "8.21.0",
@@ -21586,7 +21613,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.once": {
 			"version": "4.1.1",
@@ -21834,6 +21862,7 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -22825,7 +22854,6 @@
 			"integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.6",
 				"ajv-errors": "^1.0.1",
@@ -24370,7 +24398,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
@@ -25164,7 +25191,6 @@
 			"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -25194,6 +25220,7 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -25209,6 +25236,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -25221,7 +25249,8 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/process": {
 			"version": "0.11.10",
@@ -25553,7 +25582,6 @@
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -25617,7 +25645,6 @@
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -25655,7 +25682,6 @@
 			"integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -25901,8 +25927,7 @@
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/reflect-metadata": {
 			"version": "0.2.2",
@@ -26554,7 +26579,6 @@
 			"integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"chokidar": "^5.0.0",
 				"immutable": "^5.1.5",
@@ -28268,7 +28292,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@csstools/css-parser-algorithms": "^3.0.5",
 				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -28646,7 +28669,6 @@
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -29296,7 +29318,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -29563,8 +29584,7 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/tsyringe": {
 			"version": "4.10.0",
@@ -29615,7 +29635,6 @@
 			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -29735,7 +29754,6 @@
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -29901,7 +29919,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.3.4"
 			},
@@ -30028,7 +30045,6 @@
 			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -30298,7 +30314,6 @@
 			"integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "^1.0.8",
 				"@types/json-schema": "^7.0.15",
@@ -30405,7 +30420,6 @@
 			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^2.1.1",
@@ -30519,7 +30533,6 @@
 			"integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/bonjour": "^3.5.13",
 				"@types/connect-history-api-fallback": "^1.5.4",
@@ -31468,7 +31481,6 @@
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/src/admin/screenshot/ScreenshotScreen.tsx
+++ b/src/admin/screenshot/ScreenshotScreen.tsx
@@ -1,0 +1,177 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import {
+	Button,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { AdminHeader } from '../shared/AdminHeader';
+import { ScreenNotices } from '../shared/ScreenNotices';
+import { screenshotApi } from './api';
+import type { ScreenshotSettings } from './types';
+
+const NOTICES_CONTEXT = 'rtpwai-screenshot';
+
+export function ScreenshotScreen() {
+	const [ settings, setSettings ] = useState< ScreenshotSettings | null >(
+		null
+	);
+	const [ apiKey, setApiKey ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	useEffect( () => {
+		screenshotApi.get().then( setSettings );
+	}, [] );
+
+	if ( ! settings ) {
+		return null;
+	}
+
+	const currentProvider = settings.providers.find(
+		( p ) => p.id === settings.provider
+	);
+
+	async function handleSave() {
+		if ( ! settings ) {
+			return;
+		}
+
+		setIsSaving( true );
+
+		try {
+			const updated = await screenshotApi.update( {
+				enabled: settings.enabled,
+				provider: settings.provider,
+				api_key: apiKey,
+			} );
+			setSettings( updated );
+			setApiKey( '' );
+			createSuccessNotice(
+				__( 'Settings saved.', 'rtcamp-publish-with-ai' ),
+				{ type: 'snackbar', context: NOTICES_CONTEXT }
+			);
+		} catch {
+			createErrorNotice(
+				__(
+					'Failed to save settings. Please try again.',
+					'rtcamp-publish-with-ai'
+				),
+				{
+					type: 'snackbar',
+					context: NOTICES_CONTEXT,
+					explicitDismiss: true,
+				}
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	}
+
+	return (
+		<>
+			<AdminHeader
+				title={ __( 'Screenshots', 'rtcamp-publish-with-ai' ) }
+				description={ __(
+					'Configure screenshot capture for AI publishing previews.',
+					'rtcamp-publish-with-ai'
+				) }
+			/>
+
+			<main className="p-6">
+				<div className="bg-white rounded-lg border border-gray-200 p-6 max-w-2xl flex flex-col gap-6">
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Enable Screenshots',
+							'rtcamp-publish-with-ai'
+						) }
+						help={ __(
+							'When enabled, the AI can capture screenshots of patterns and pages during publishing.',
+							'rtcamp-publish-with-ai'
+						) }
+						checked={ settings.enabled }
+						onChange={ ( enabled ) =>
+							setSettings( ( s ) =>
+								s ? { ...s, enabled } : s
+							)
+						}
+					/>
+
+					{ settings.enabled && (
+						<>
+							<SelectControl
+								__nextHasNoMarginBottom
+								label={ __(
+									'Provider',
+									'rtcamp-publish-with-ai'
+								) }
+								value={ settings.provider }
+								options={ settings.providers.map( ( p ) => ( {
+									value: p.id,
+									label: p.label,
+								} ) ) }
+								onChange={ ( provider ) =>
+									setSettings( ( s ) =>
+										s ? { ...s, provider } : s
+									)
+								}
+							/>
+
+							<TextControl
+								__nextHasNoMarginBottom
+								label={
+									currentProvider?.key_label ??
+									__( 'API Key', 'rtcamp-publish-with-ai' )
+								}
+								type="password"
+								value={ apiKey }
+								placeholder={
+									settings.has_api_key
+										? __(
+												'Leave blank to keep current key',
+												'rtcamp-publish-with-ai'
+										  )
+										: ''
+								}
+								help={
+									currentProvider?.requires_key === false
+										? __(
+												'Optional — providing a key unlocks higher rate limits.',
+												'rtcamp-publish-with-ai'
+										  )
+										: undefined
+								}
+								onChange={ setApiKey }
+							/>
+						</>
+					) }
+
+					<div>
+						<Button
+							variant="primary"
+							onClick={ handleSave }
+							isBusy={ isSaving }
+							disabled={ isSaving }
+						>
+							{ __( 'Save', 'rtcamp-publish-with-ai' ) }
+						</Button>
+					</div>
+				</div>
+			</main>
+
+			<ScreenNotices context={ NOTICES_CONTEXT } />
+		</>
+	);
+}

--- a/src/admin/screenshot/api.ts
+++ b/src/admin/screenshot/api.ts
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import type { ScreenshotSettings, UpdateScreenshotPayload } from './types';
+
+const REST_PATH = '/rtpwai/v1/screenshot-settings';
+
+export const screenshotApi = {
+	get: (): Promise< ScreenshotSettings > => apiFetch( { path: REST_PATH } ),
+
+	update: ( data: UpdateScreenshotPayload ): Promise< ScreenshotSettings > =>
+		apiFetch( { path: REST_PATH, method: 'PUT', data } ),
+};

--- a/src/admin/screenshot/index.tsx
+++ b/src/admin/screenshot/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { StrictMode, createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ScreenshotScreen } from './ScreenshotScreen';
+
+import '../../tailwind.scss';
+import '../styles/styles.scss';
+
+const root = document.querySelector( '#rtpwai-screenshot-screen-root' );
+
+if ( root ) {
+	createRoot( root ).render(
+		<StrictMode>
+			<ScreenshotScreen />
+		</StrictMode>
+	);
+}

--- a/src/admin/screenshot/types.ts
+++ b/src/admin/screenshot/types.ts
@@ -1,0 +1,19 @@
+export interface Provider {
+	id: string;
+	label: string;
+	requires_key: boolean;
+	key_label: string;
+}
+
+export interface ScreenshotSettings {
+	enabled: boolean;
+	provider: string;
+	has_api_key: boolean;
+	providers: Provider[];
+}
+
+export interface UpdateScreenshotPayload {
+	enabled: boolean;
+	provider: string;
+	api_key: string;
+}

--- a/src/admin/settings/SettingsScreen.tsx
+++ b/src/admin/settings/SettingsScreen.tsx
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { AdminHeader } from '../shared/AdminHeader';
+import { ScreenNotices } from '../shared/ScreenNotices';
+import { ScreenshotSection } from './sections/ScreenshotSection';
+
+const NOTICES_CONTEXT = 'rtpwai-settings';
+
+export function SettingsScreen() {
+	return (
+		<>
+			<AdminHeader
+				title={ __( 'Settings', 'rtcamp-publish-with-ai' ) }
+				description={ __(
+					'Configure plugin behaviour and integrations.',
+					'rtcamp-publish-with-ai'
+				) }
+			/>
+
+			<main className="p-6 flex flex-col gap-6">
+				<section className="bg-white rounded-lg border border-gray-200 p-6 max-w-2xl">
+					<h2 className="mt-0 mb-4 text-sm font-semibold text-gray-900">
+						{ __( 'Screenshots', 'rtcamp-publish-with-ai' ) }
+					</h2>
+
+					<ScreenshotSection noticesContext={ NOTICES_CONTEXT } />
+				</section>
+			</main>
+
+			<ScreenNotices context={ NOTICES_CONTEXT } />
+		</>
+	);
+}

--- a/src/admin/settings/index.tsx
+++ b/src/admin/settings/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { StrictMode, createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { SettingsScreen } from './SettingsScreen';
+
+import '../../tailwind.scss';
+import '../styles/styles.scss';
+
+const root = document.querySelector( '#rtpwai-settings-screen-root' );
+
+if ( root ) {
+	createRoot( root ).render(
+		<StrictMode>
+			<SettingsScreen />
+		</StrictMode>
+	);
+}

--- a/src/admin/settings/sections/ScreenshotSection.tsx
+++ b/src/admin/settings/sections/ScreenshotSection.tsx
@@ -1,0 +1,159 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import {
+	Button,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { screenshotApi } from '../../screenshot/api';
+import type { ScreenshotSettings } from '../../screenshot/types';
+
+const NOTICES_CONTEXT = 'rtpwai-settings';
+
+interface Props {
+	noticesContext?: string;
+}
+
+export function ScreenshotSection( {
+	noticesContext = NOTICES_CONTEXT,
+}: Props ) {
+	const [ settings, setSettings ] = useState< ScreenshotSettings | null >(
+		null
+	);
+	const [ apiKey, setApiKey ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	useEffect( () => {
+		screenshotApi.get().then( setSettings );
+	}, [] );
+
+	if ( ! settings ) {
+		return null;
+	}
+
+	const currentProvider = settings.providers.find(
+		( p ) => p.id === settings.provider
+	);
+
+	async function handleSave() {
+		if ( ! settings ) {
+			return;
+		}
+
+		setIsSaving( true );
+
+		try {
+			const updated = await screenshotApi.update( {
+				enabled: settings.enabled,
+				provider: settings.provider,
+				api_key: apiKey,
+			} );
+			setSettings( updated );
+			setApiKey( '' );
+			createSuccessNotice(
+				__( 'Settings saved.', 'rtcamp-publish-with-ai' ),
+				{ type: 'snackbar', context: noticesContext }
+			);
+		} catch {
+			createErrorNotice(
+				__(
+					'Failed to save settings. Please try again.',
+					'rtcamp-publish-with-ai'
+				),
+				{
+					type: 'snackbar',
+					context: noticesContext,
+					explicitDismiss: true,
+				}
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-6">
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Enable Screenshots', 'rtcamp-publish-with-ai' ) }
+				help={ __(
+					'When enabled, the AI can capture screenshots of patterns and pages during publishing.',
+					'rtcamp-publish-with-ai'
+				) }
+				checked={ settings.enabled }
+				onChange={ ( enabled ) =>
+					setSettings( ( s ) => ( s ? { ...s, enabled } : s ) )
+				}
+			/>
+
+			{ settings.enabled && (
+				<>
+					<SelectControl
+						__nextHasNoMarginBottom
+						label={ __( 'Provider', 'rtcamp-publish-with-ai' ) }
+						value={ settings.provider }
+						options={ settings.providers.map( ( p ) => ( {
+							value: p.id,
+							label: p.label,
+						} ) ) }
+						onChange={ ( provider ) =>
+							setSettings( ( s ) =>
+								s ? { ...s, provider } : s
+							)
+						}
+					/>
+
+					<TextControl
+						__nextHasNoMarginBottom
+						label={
+							currentProvider?.key_label ??
+							__( 'API Key', 'rtcamp-publish-with-ai' )
+						}
+						type="password"
+						value={ apiKey }
+						placeholder={
+							settings.has_api_key
+								? __(
+										'Leave blank to keep current key',
+										'rtcamp-publish-with-ai'
+								  )
+								: ''
+						}
+						help={
+							currentProvider?.requires_key === false
+								? __(
+										'Optional — providing a key unlocks higher rate limits.',
+										'rtcamp-publish-with-ai'
+								  )
+								: undefined
+						}
+						onChange={ setApiKey }
+					/>
+				</>
+			) }
+
+			<div>
+				<Button
+					variant="primary"
+					onClick={ handleSave }
+					isBusy={ isSaving }
+					disabled={ isSaving }
+				>
+					{ __( 'Save', 'rtcamp-publish-with-ai' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/templates/screenshot-screen.php
+++ b/templates/screenshot-screen.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Template for the Screenshot settings screen.
+ *
+ * @package rtcamp-publish-with-ai
+ */
+
+declare(strict_types = 1);
+
+?>
+
+<div id="rtpwai-screenshot-screen-root" class="rtpwai-tailwind"></div>

--- a/templates/settings-screen.php
+++ b/templates/settings-screen.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Template for the Settings admin screen.
+ *
+ * @package rtcamp-publish-with-ai
+ */
+
+declare(strict_types = 1);
+
+?>
+
+<div id="rtpwai-settings-screen-root" class="rtpwai-tailwind"></div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,10 @@ const scriptEntries = {
 		import.meta.dirname,
 		'src/admin/credentials/index.tsx'
 	),
+	'admin-settings': path.resolve(
+		import.meta.dirname,
+		'src/admin/settings/index.tsx'
+	),
 	'admin-menu-icon': path.resolve(
 		import.meta.dirname,
 		'src/admin/styles/menu-icon.scss'


### PR DESCRIPTION
## Summary

Adds an MCP tool (`rtpwai/screenshot-post`) that captures a screenshot of any WordPress post or page and returns a public URL so Claude can embed it inline as a Markdown image (`![Screenshot](url)`).

- **`Screenshot_Image_Endpoint`** — new REST route `GET /rtpwai/v1/screenshot-image?token={token}` that serves a short-lived PNG. The binary is stored base64-encoded in a transient (avoids corruption in MySQL `utf8mb4` text columns) and decoded on serve.
- **`Screenshot_Post` MCP ability** — pre-renders the post HTML inside the MCP tool context (before calling the screenshot API), so the preview endpoint can answer Microlink/ScreenshotOne instantly from cache without a slow loopback inside the provider's timeout window.
- **`Preview_Endpoint`** — `fetch_page_html()` promoted to `public static`; added `HTML_PREFIX` constant for the pre-render transient key; `serve()` reads from the pre-render cache and falls back to a live loopback only if the cache is missing.
- **`Microlink_Provider`** — `element` CSS selector param is now only sent when an API key is present (it is a Pro-only feature; omitting it on the free tier fixes the `EBRWSRTIMEOUT` rejection). Microlink API errors are now surfaced in `WP_Error` data.
- **Screenshot Settings page** — admin UI (React/TSX + PHP template) for enabling the feature and selecting/configuring the provider.
- **`Main`** — registers `Screenshot_Image_Endpoint`; adds `maybe_upgrade` hook so DB migrations run on version bump without requiring deactivation/reactivation.

## Test plan

- [ ] Configure a screenshot provider under **Settings → Screenshots**
- [ ] Ask Claude (via MCP): *"Screenshot post ID 1"* — Claude should respond with an embedded image
- [ ] Visit the `screenshot-image` URL directly — should return a `image/png` response
- [ ] With **no API key + Microlink**: confirm no `microlink_failed` error (full-viewport screenshot returned)
- [ ] With **ScreenshotOne**: confirm element-level crop works
- [ ] After the token TTL (1 hour), confirm the URL returns 404