### PR TITLE
feat: add taxonomy/Yoast MCP abilities, skill file, and uninstall cleanup

### DIFF
--- a/inc/Main.php
+++ b/inc/Main.php
@@ -107,6 +107,7 @@ final class Main {
 		Modules\MCP\OAuth\Storage\Token_Store::create_table();
 		Modules\MCP\OAuth\Storage\Client_Store::create_table();
 		update_option( 'publish_with_ai_version', RTCAMP_PUBLISH_WITH_AI_VERSION );
+		flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
 	}
 
 	/**

--- a/inc/Modules/MCP/Abilities/Abilities.php
+++ b/inc/Modules/MCP/Abilities/Abilities.php
@@ -26,11 +26,16 @@ use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Append_Pattern;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Create_Post;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Delete_Block_At;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Get_Post;
+use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Get_Post_Terms;
+use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Get_Taxonomy_Terms;
+use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Get_Yoast_Meta;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Insert_Blocks_At;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Insert_Pattern_At;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Search_Attachments;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Search_Posts;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Set_Featured_Image;
+use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Set_Post_Terms;
+use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Set_Yoast_Meta;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Update_Post;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts\Upload_Media;
 use rtCamp\Publish_With_AI\Modules\MCP\Abilities\Preview\Screenshot_Post;
@@ -96,6 +101,11 @@ final class Abilities implements Registrable {
 			new Search_Attachments(),
 			new Upload_Media(),
 			new Screenshot_Post(),
+			new Get_Taxonomy_Terms(),
+			new Get_Post_Terms(),
+			new Set_Post_Terms(),
+			new Get_Yoast_Meta(),
+			new Set_Yoast_Meta(),
 		];
 
 		foreach ( $abilities as $ability ) {

--- a/inc/Modules/MCP/Abilities/Posts/Get_Post_Terms.php
+++ b/inc/Modules/MCP/Abilities/Posts/Get_Post_Terms.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Get Post Terms ability.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts;
+
+/**
+ * Class - Get_Post_Terms
+ */
+class Get_Post_Terms {
+	/**
+	 * Register the ability.
+	 */
+	public function register(): void {
+		wp_register_ability(
+			'rtpwai/get-post-terms',
+			[
+				'label'               => __( 'Get Post Terms', 'rtcamp-publish-with-ai' ),
+				'category'            => \rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Posts::SLUG,
+				'description'         => __( 'Returns the taxonomy terms currently assigned to a post (e.g. its categories and tags).', 'rtcamp-publish-with-ai' ),
+				'input_schema'        => [
+					'type'                 => 'object',
+					'required'             => [ 'post_id' ],
+					'properties'           => [
+						'post_id'  => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => 'ID of the post.',
+						],
+						'taxonomy' => [
+							'type'        => 'string',
+							'description' => 'Taxonomy slug to filter by (e.g. "category", "post_tag"). Omit to return all taxonomies.',
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'required'   => [ 'post_id', 'taxonomies' ],
+					'properties' => [
+						'post_id'    => [ 'type' => 'integer' ],
+						'taxonomies' => [
+							'type'                 => 'object',
+							'additionalProperties' => [
+								'type'  => 'array',
+								'items' => [
+									'type'       => 'object',
+									'required'   => [ 'term_id', 'name', 'slug' ],
+									'properties' => [
+										'term_id' => [ 'type' => 'integer' ],
+										'name'    => [ 'type' => 'string' ],
+										'slug'    => [ 'type' => 'string' ],
+									],
+								],
+							],
+						],
+					],
+				],
+				'permission_callback' => static function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'execute_callback'    => static function ( array $input ) {
+					$post_id = (int) ( $input['post_id'] ?? 0 );
+					$post    = get_post( $post_id );
+
+					if ( ! $post ) {
+						return new \WP_Error( 'invalid_post', __( 'Post not found.', 'rtcamp-publish-with-ai' ) );
+					}
+
+					if ( ! empty( $input['taxonomy'] ) ) {
+						$taxonomies = [ sanitize_key( $input['taxonomy'] ) ];
+					} else {
+						$taxonomies = get_object_taxonomies( $post->post_type );
+					}
+
+					$result = [];
+					foreach ( $taxonomies as $taxonomy ) {
+						if ( ! taxonomy_exists( $taxonomy ) ) {
+							continue;
+						}
+						$terms = get_the_terms( $post_id, $taxonomy );
+						if ( ! $terms || is_wp_error( $terms ) ) {
+							$result[ $taxonomy ] = [];
+							continue;
+						}
+						$result[ $taxonomy ] = array_map(
+							static function ( $term ) {
+								return [
+									'term_id' => $term->term_id,
+									'name'    => $term->name,
+									'slug'    => $term->slug,
+								];
+							},
+							$terms
+						);
+					}
+
+					return [
+						'post_id'    => $post_id,
+						'taxonomies' => $result,
+					];
+				},
+				'meta'                => [
+					'show_in_rest' => true,
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'mcp'          => [
+						'public' => true,
+					],
+				],
+			]
+		);
+	}
+}

--- a/inc/Modules/MCP/Abilities/Posts/Get_Taxonomy_Terms.php
+++ b/inc/Modules/MCP/Abilities/Posts/Get_Taxonomy_Terms.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Get Taxonomy Terms ability.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts;
+
+/**
+ * Class - Get_Taxonomy_Terms
+ */
+class Get_Taxonomy_Terms {
+	/**
+	 * Register the ability.
+	 */
+	public function register(): void {
+		wp_register_ability(
+			'rtpwai/get-taxonomy-terms',
+			[
+				'label'               => __( 'List Taxonomy Terms', 'rtcamp-publish-with-ai' ),
+				'category'            => \rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Posts::SLUG,
+				'description'         => __( 'Returns available terms for a taxonomy (e.g. "category", "post_tag"). Use this to discover valid categories or tags before assigning them to a post.', 'rtcamp-publish-with-ai' ),
+				'input_schema'        => [
+					'type'                 => 'object',
+					'required'             => [ 'taxonomy' ],
+					'properties'           => [
+						'taxonomy' => [
+							'type'        => 'string',
+							'description' => 'Taxonomy slug, e.g. "category" or "post_tag".',
+						],
+						'search'   => [
+							'type'        => 'string',
+							'description' => 'Optional search string to filter terms by name.',
+						],
+						'per_page' => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'maximum'     => 100,
+							'default'     => 50,
+							'description' => 'Maximum number of terms to return. Defaults to 50.',
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'required'   => [ 'taxonomy', 'terms' ],
+					'properties' => [
+						'taxonomy' => [ 'type' => 'string' ],
+						'terms'    => [
+							'type'  => 'array',
+							'items' => [
+								'type'       => 'object',
+								'required'   => [ 'term_id', 'name', 'slug', 'count' ],
+								'properties' => [
+									'term_id'     => [ 'type' => 'integer' ],
+									'name'        => [ 'type' => 'string' ],
+									'slug'        => [ 'type' => 'string' ],
+									'count'       => [ 'type' => 'integer' ],
+									'description' => [ 'type' => 'string' ],
+									'parent_id'   => [ 'type' => 'integer' ],
+								],
+							],
+						],
+					],
+				],
+				'permission_callback' => static function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'execute_callback'    => static function ( array $input ) {
+					$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
+
+					if ( ! taxonomy_exists( $taxonomy ) ) {
+						return new \WP_Error( 'invalid_taxonomy', __( 'Taxonomy does not exist.', 'rtcamp-publish-with-ai' ) );
+					}
+
+					$args = [
+						'taxonomy'   => $taxonomy,
+						'hide_empty' => false,
+						'number'     => (int) ( $input['per_page'] ?? 50 ),
+						'orderby'    => 'count',
+						'order'      => 'DESC',
+					];
+
+					if ( ! empty( $input['search'] ) ) {
+						$args['search'] = sanitize_text_field( $input['search'] );
+					}
+
+					$terms = get_terms( $args );
+
+					if ( is_wp_error( $terms ) ) {
+						return $terms;
+					}
+
+					$result = [];
+					foreach ( $terms as $term ) {
+						$result[] = [
+							'term_id'     => $term->term_id,
+							'name'        => $term->name,
+							'slug'        => $term->slug,
+							'count'       => $term->count,
+							'description' => $term->description,
+							'parent_id'   => $term->parent,
+						];
+					}
+
+					return [
+						'taxonomy' => $taxonomy,
+						'terms'    => $result,
+					];
+				},
+				'meta'                => [
+					'show_in_rest' => true,
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'mcp'          => [
+						'public' => true,
+					],
+				],
+			]
+		);
+	}
+}

--- a/inc/Modules/MCP/Abilities/Posts/Get_Yoast_Meta.php
+++ b/inc/Modules/MCP/Abilities/Posts/Get_Yoast_Meta.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Get Yoast SEO Meta ability.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts;
+
+/**
+ * Class - Get_Yoast_Meta
+ */
+class Get_Yoast_Meta {
+	/**
+	 * Register the ability.
+	 */
+	public function register(): void {
+		wp_register_ability(
+			'rtpwai/get-yoast-meta',
+			[
+				'label'               => __( 'Get Yoast SEO Metadata', 'rtcamp-publish-with-ai' ),
+				'category'            => \rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Posts::SLUG,
+				'description'         => __( 'Returns Yoast SEO metadata for a post — SEO title, meta description, focus keyphrase, canonical URL, and robots settings. Returns an error if Yoast SEO is not active.', 'rtcamp-publish-with-ai' ),
+				'input_schema'        => [
+					'type'                 => 'object',
+					'required'             => [ 'post_id' ],
+					'properties'           => [
+						'post_id' => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => 'ID of the post or page.',
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'required'   => [ 'post_id' ],
+					'properties' => [
+						'post_id'             => [ 'type' => 'integer' ],
+						'seo_title'           => [ 'type' => 'string' ],
+						'meta_description'    => [ 'type' => 'string' ],
+						'focus_keyphrase'     => [ 'type' => 'string' ],
+						'canonical'           => [ 'type' => 'string' ],
+						'noindex'             => [ 'type' => 'boolean' ],
+						'nofollow'            => [ 'type' => 'boolean' ],
+						'og_title'            => [ 'type' => 'string' ],
+						'og_description'      => [ 'type' => 'string' ],
+						'twitter_title'       => [ 'type' => 'string' ],
+						'twitter_description' => [ 'type' => 'string' ],
+						'schema_page_type'    => [ 'type' => 'string' ],
+						'schema_article_type' => [ 'type' => 'string' ],
+					],
+				],
+				'permission_callback' => static function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'execute_callback'    => static function ( array $input ) {
+					if ( ! defined( 'WPSEO_VERSION' ) ) {
+						return new \WP_Error( 'yoast_not_active', __( 'Yoast SEO is not installed or active.', 'rtcamp-publish-with-ai' ) );
+					}
+
+					$post_id = (int) ( $input['post_id'] ?? 0 );
+					if ( ! get_post( $post_id ) ) {
+						return new \WP_Error( 'invalid_post', __( 'Post not found.', 'rtcamp-publish-with-ai' ) );
+					}
+
+					$get = static function ( string $key ) use ( $post_id ): string {
+						return (string) ( get_post_meta( $post_id, $key, true ) ?: '' );
+					};
+
+					return [
+						'post_id'             => $post_id,
+						'seo_title'           => $get( '_yoast_wpseo_title' ),
+						'meta_description'    => $get( '_yoast_wpseo_metadesc' ),
+						'focus_keyphrase'     => $get( '_yoast_wpseo_focuskw' ),
+						'canonical'           => $get( '_yoast_wpseo_canonical' ),
+						'noindex'             => (bool) $get( '_yoast_wpseo_meta-robots-noindex' ),
+						'nofollow'            => (bool) $get( '_yoast_wpseo_meta-robots-nofollow' ),
+						'og_title'            => $get( '_yoast_wpseo_opengraph-title' ),
+						'og_description'      => $get( '_yoast_wpseo_opengraph-description' ),
+						'twitter_title'       => $get( '_yoast_wpseo_twitter-title' ),
+						'twitter_description' => $get( '_yoast_wpseo_twitter-description' ),
+						'schema_page_type'    => $get( '_yoast_wpseo_schema_page_type' ),
+						'schema_article_type' => $get( '_yoast_wpseo_schema_article_type' ),
+					];
+				},
+				'meta'                => [
+					'show_in_rest' => true,
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'mcp'          => [
+						'public' => true,
+					],
+				],
+			]
+		);
+	}
+}

--- a/inc/Modules/MCP/Abilities/Posts/Set_Post_Terms.php
+++ b/inc/Modules/MCP/Abilities/Posts/Set_Post_Terms.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Set Post Terms ability.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts;
+
+/**
+ * Class - Set_Post_Terms
+ */
+class Set_Post_Terms {
+	/**
+	 * Register the ability.
+	 */
+	public function register(): void {
+		wp_register_ability(
+			'rtpwai/set-post-terms',
+			[
+				'label'               => __( 'Set Post Categories or Tags', 'rtcamp-publish-with-ai' ),
+				'category'            => \rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Posts::SLUG,
+				'description'         => __( 'Assigns taxonomy terms (categories, tags, or custom taxonomies) to a post, replacing any existing terms for that taxonomy. Pass term slugs or IDs. Use rtpwai/get-taxonomy-terms first to discover valid values.', 'rtcamp-publish-with-ai' ),
+				'input_schema'        => [
+					'type'                 => 'object',
+					'required'             => [ 'post_id', 'taxonomy', 'terms' ],
+					'properties'           => [
+						'post_id'  => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => 'ID of the post.',
+						],
+						'taxonomy' => [
+							'type'        => 'string',
+							'description' => 'Taxonomy slug, e.g. "category" or "post_tag".',
+						],
+						'terms'    => [
+							'type'        => 'array',
+							'description' => 'Term slugs or integer IDs to assign. Pass an empty array to remove all terms.',
+							'items'       => [
+								'oneOf' => [
+									[ 'type' => 'string' ],
+									[
+										'type'    => 'integer',
+										'minimum' => 1,
+									],
+								],
+							],
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'required'   => [ 'success', 'post_id', 'taxonomy', 'assigned_terms' ],
+					'properties' => [
+						'success'        => [ 'type' => 'boolean' ],
+						'post_id'        => [ 'type' => 'integer' ],
+						'taxonomy'       => [ 'type' => 'string' ],
+						'assigned_terms' => [
+							'type'  => 'array',
+							'items' => [
+								'type'       => 'object',
+								'properties' => [
+									'term_id' => [ 'type' => 'integer' ],
+									'name'    => [ 'type' => 'string' ],
+									'slug'    => [ 'type' => 'string' ],
+								],
+							],
+						],
+					],
+				],
+				'permission_callback' => static function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'execute_callback'    => static function ( array $input ) {
+					$post_id  = (int) ( $input['post_id'] ?? 0 );
+					$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
+					$terms    = $input['terms'] ?? [];
+
+					$post = get_post( $post_id );
+					if ( ! $post ) {
+						return new \WP_Error( 'invalid_post', __( 'Post not found.', 'rtcamp-publish-with-ai' ) );
+					}
+
+					if ( ! taxonomy_exists( $taxonomy ) ) {
+						return new \WP_Error( 'invalid_taxonomy', __( 'Taxonomy does not exist.', 'rtcamp-publish-with-ai' ) );
+					}
+
+					if ( ! is_object_in_taxonomy( $post->post_type, $taxonomy ) ) {
+						return new \WP_Error(
+							'taxonomy_not_registered',
+							sprintf(
+								/* translators: 1: taxonomy slug, 2: post type slug */
+								__( 'Taxonomy "%1$s" is not registered for post type "%2$s".', 'rtcamp-publish-with-ai' ),
+								$taxonomy,
+								$post->post_type
+							)
+						);
+					}
+
+					// Resolve slugs to term IDs.
+					$term_ids = [];
+					foreach ( $terms as $term ) {
+						if ( is_int( $term ) || ctype_digit( (string) $term ) ) {
+							$term_ids[] = (int) $term;
+						} else {
+							$term_obj = get_term_by( 'slug', sanitize_title( $term ), $taxonomy );
+							if ( ! $term_obj ) {
+								return new \WP_Error(
+									'invalid_term',
+									sprintf(
+										/* translators: 1: term slug, 2: taxonomy slug */
+										__( 'Term "%1$s" not found in taxonomy "%2$s".', 'rtcamp-publish-with-ai' ),
+										$term,
+										$taxonomy
+									)
+								);
+							}
+							$term_ids[] = $term_obj->term_id;
+						}
+					}
+
+					$result = wp_set_post_terms( $post_id, $term_ids, $taxonomy );
+
+					if ( is_wp_error( $result ) ) {
+						return $result;
+					}
+
+					$assigned       = get_the_terms( $post_id, $taxonomy ) ?: [];
+					$assigned_terms = array_map(
+						static function ( $term ) {
+							return [
+								'term_id' => $term->term_id,
+								'name'    => $term->name,
+								'slug'    => $term->slug,
+							];
+						},
+						is_array( $assigned ) ? $assigned : []
+					);
+
+					return [
+						'success'        => true,
+						'post_id'        => $post_id,
+						'taxonomy'       => $taxonomy,
+						'assigned_terms' => $assigned_terms,
+					];
+				},
+				'meta'                => [
+					'show_in_rest' => true,
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'mcp'          => [
+						'public' => true,
+					],
+				],
+			]
+		);
+	}
+}

--- a/inc/Modules/MCP/Abilities/Posts/Set_Yoast_Meta.php
+++ b/inc/Modules/MCP/Abilities/Posts/Set_Yoast_Meta.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Set Yoast SEO Meta ability.
+ *
+ * @package rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Publish_With_AI\Modules\MCP\Abilities\Posts;
+
+/**
+ * Class - Set_Yoast_Meta
+ */
+class Set_Yoast_Meta {
+	/**
+	 * Register the ability.
+	 */
+	public function register(): void {
+		wp_register_ability(
+			'rtpwai/set-yoast-meta',
+			[
+				'label'               => __( 'Set Yoast SEO Metadata', 'rtcamp-publish-with-ai' ),
+				'category'            => \rtCamp\Publish_With_AI\Modules\MCP\Abilities\Categories\Posts::SLUG,
+				'description'         => __( 'Writes Yoast SEO metadata for a post. Only provided fields are updated — omitted fields are left unchanged. Returns an error if Yoast SEO is not active.', 'rtcamp-publish-with-ai' ),
+				'input_schema'        => [
+					'type'                 => 'object',
+					'required'             => [ 'post_id' ],
+					'properties'           => [
+						'post_id'             => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => 'ID of the post or page.',
+						],
+						'seo_title'           => [
+							'type'        => 'string',
+							'description' => 'SEO title shown in search results. Supports Yoast replacement variables (e.g. %%title%% %%sep%% %%sitename%%).',
+						],
+						'meta_description'    => [
+							'type'        => 'string',
+							'description' => 'Meta description shown in search results (recommended 120–156 characters).',
+						],
+						'focus_keyphrase'     => [
+							'type'        => 'string',
+							'description' => 'The primary keyphrase this post should rank for.',
+						],
+						'canonical'           => [
+							'type'        => 'string',
+							'description' => 'Canonical URL override. Leave empty to use the default permalink.',
+						],
+						'noindex'             => [
+							'type'        => 'boolean',
+							'description' => 'Set to true to add a noindex robots directive.',
+						],
+						'nofollow'            => [
+							'type'        => 'boolean',
+							'description' => 'Set to true to add a nofollow robots directive.',
+						],
+						'og_title'            => [
+							'type'        => 'string',
+							'description' => 'Open Graph title (used by Facebook and other social platforms).',
+						],
+						'og_description'      => [
+							'type'        => 'string',
+							'description' => 'Open Graph description.',
+						],
+						'twitter_title'       => [
+							'type'        => 'string',
+							'description' => 'Twitter card title.',
+						],
+						'twitter_description' => [
+							'type'        => 'string',
+							'description' => 'Twitter card description.',
+						],
+						'schema_page_type'    => [
+							'type'        => 'string',
+							'description' => 'Yoast Schema page type (e.g. "WebPage", "FAQPage", "ItemPage").',
+						],
+						'schema_article_type' => [
+							'type'        => 'string',
+							'description' => 'Yoast Schema article type (e.g. "Article", "BlogPosting", "NewsArticle").',
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'required'   => [ 'success', 'post_id', 'updated_fields' ],
+					'properties' => [
+						'success'        => [ 'type' => 'boolean' ],
+						'post_id'        => [ 'type' => 'integer' ],
+						'updated_fields' => [
+							'type'  => 'array',
+							'items' => [ 'type' => 'string' ],
+						],
+					],
+				],
+				'permission_callback' => static function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'execute_callback'    => static function ( array $input ) {
+					if ( ! defined( 'WPSEO_VERSION' ) ) {
+						return new \WP_Error( 'yoast_not_active', __( 'Yoast SEO is not installed or active.', 'rtcamp-publish-with-ai' ) );
+					}
+
+					$post_id = (int) ( $input['post_id'] ?? 0 );
+					if ( ! get_post( $post_id ) ) {
+						return new \WP_Error( 'invalid_post', __( 'Post not found.', 'rtcamp-publish-with-ai' ) );
+					}
+
+					$field_map = [
+						'seo_title'           => '_yoast_wpseo_title',
+						'meta_description'    => '_yoast_wpseo_metadesc',
+						'focus_keyphrase'     => '_yoast_wpseo_focuskw',
+						'canonical'           => '_yoast_wpseo_canonical',
+						'og_title'            => '_yoast_wpseo_opengraph-title',
+						'og_description'      => '_yoast_wpseo_opengraph-description',
+						'twitter_title'       => '_yoast_wpseo_twitter-title',
+						'twitter_description' => '_yoast_wpseo_twitter-description',
+						'schema_page_type'    => '_yoast_wpseo_schema_page_type',
+						'schema_article_type' => '_yoast_wpseo_schema_article_type',
+					];
+
+					$bool_field_map = [
+						'noindex'  => '_yoast_wpseo_meta-robots-noindex',
+						'nofollow' => '_yoast_wpseo_meta-robots-nofollow',
+					];
+
+					$updated = [];
+
+					foreach ( $field_map as $input_key => $meta_key ) {
+						if ( ! isset( $input[ $input_key ] ) ) {
+							continue;
+						}
+						update_post_meta( $post_id, $meta_key, sanitize_text_field( $input[ $input_key ] ) );
+						$updated[] = $input_key;
+					}
+
+					foreach ( $bool_field_map as $input_key => $meta_key ) {
+						if ( ! isset( $input[ $input_key ] ) ) {
+							continue;
+						}
+						update_post_meta( $post_id, $meta_key, $input[ $input_key ] ? '1' : '0' );
+						$updated[] = $input_key;
+					}
+
+					return [
+						'success'        => true,
+						'post_id'        => $post_id,
+						'updated_fields' => $updated,
+					];
+				},
+				'meta'                => [
+					'show_in_rest' => true,
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'mcp'          => [
+						'public' => true,
+					],
+				],
+			]
+		);
+	}
+}

--- a/inc/Modules/MCP/Server/Server.php
+++ b/inc/Modules/MCP/Server/Server.php
@@ -41,7 +41,7 @@ class Server implements Registrable {
 			self::SERVER_ID,
 			'mcp',
 			self::SERVER_ID,
-			__( 'Publish with AI', 'rtcamp-publish-with-ai' ),
+			__( 'Publish With AI — rtCamp', 'rtcamp-publish-with-ai' ),
 			__( 'MCP server for the Publish with AI plugin.', 'rtcamp-publish-with-ai' ),
 			RTCAMP_PUBLISH_WITH_AI_VERSION,
 			[ HttpTransport::class ],

--- a/skills/rt-publish-with-ai/SKILL.md
+++ b/skills/rt-publish-with-ai/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: rt-publish-with-ai
+description: Generates WordPress content using the site's existing patterns (never custom blocks), assembled via pattern schemas and built up incrementally rather than written in one shot. Landing pages are pattern-only; blog posts may use direct block markup for plain prose (paragraphs, headings, lists, quotes, inline images) but still use the pattern-schema workflow for any structured section. Use whenever the user asks to "write a blog post", "create a landing page", "add a section", "draft content", "build a page", or mentions WordPress content creation, page assembly, or publishing workflows. Use this skill even if the user doesn't explicitly mention patterns or schemas — the schema-first, incremental approach is how WordPress content should be produced in this site, period.
+---
+
+# WordPress Content Generation
+
+Two non-negotiable mechanics:
+
+1. **Schema-first for patterns.** Never hand-write pattern markup. Fetch the pattern's schema, mutate its attributes, render markup from the schema. Exception: in **blog posts**, plain prose blocks (paragraphs, headings, lists, quotes, inline images) may be written as direct block markup. In **landing pages**, no exception — every block comes from a pattern.
+2. **Incremental assembly by append.** Never draft a full page in one go. Create an empty draft, then append one section at a time directly to the end of the current content.
+
+Hand-written pattern markup drifts from the design system. One-shot drafts produce invalid markup and lose work mid-generation. These mechanics keep generation deterministic and recoverable.
+
+---
+
+## Critical Rules
+
+- **Landing pages: patterns only.** No custom blocks, no raw markup. If no pattern fits, stop and tell the user.
+- **Blog posts: prose may be direct block markup**, but anything structured (cards, CTAs, heroes, columns, galleries, testimonials) still goes through the pattern-schema workflow. Custom blocks remain banned.
+- **Never write pattern markup by hand.** Always: fetch schema → mutate attributes → render markup → append.
+- **Size-fit before committing.** Render the pattern (or read its schema's layout) to see how much each slot actually shows. Tailor copy to the pattern, not the reverse.
+- **Append, don't rewrite.** Each section is added to the end of existing content via the site's append/update mechanism — never regenerate the whole document.
+- **Discover before planning.** Fetch all available patterns from the site every time. Don't rely on memory.
+- **Resolve media before content.** Identify every image/video, search the library, ask for uploads if missing. Don't proceed until resolved.
+- **Draft content in chat first.** Show prose, headlines, and CTA labels for approval _before_ touching schemas or WordPress.
+- **Always ask questions interactively using the `ask_user_input` tool.** Never ask clarifying questions as prose bullet points. Every question that requires a choice — images, CTA URLs, tone, audience, sections, publish status, etc. — must be presented as interactive buttons so the user taps rather than types. Minimise typing to zero wherever possible.
+- **Always create as draft** unless the user explicitly says to publish.
+- **No custom HTML** outside standard block markup.
+- **Share links as clickable** — never inside code blocks.
+- **Never surface internal errors or retries to the user.** If a tool call fails, retries, or returns an unexpected result, handle it silently. Never say "trying again", "that returned an error", "now attempting", or any variation. Only communicate outcomes that matter to the user.
+
+---
+
+## The Pattern-Schema Workflow
+
+The only acceptable way to place a pattern. Applies to posts and landing pages alike.
+
+1. **Fetch the pattern schema** — the authoritative description of attributes (text, image refs, links, button labels, repeating-item counts).
+2. **Render the pattern** with default content to see how each slot is sized. This determines what copy actually fits without clipping or ugly wrap. If a slot is too small for the user's content, pick a different pattern.
+3. **Identify changeable attributes.** You change _values only_: text, image IDs/URLs, link hrefs, button labels, and (where supported) the count of repeating items. You do **not** touch markup structure, CSS classes, inline styles, spacing, or colors. If the user wants something not in the schema, say so and propose a different pattern.
+4. **Mutate the schema** — edit the structured data, not rendered markup.
+5. **Render markup from the mutated schema** using the site's rendering mechanism. The markup you insert is the output of this step, never something typed by hand.
+6. **Append the rendered markup** to the draft (see below).
+
+**Repeating items**: you may _reduce_ count by removing entries. You may not _add_ beyond the pattern's design. If you need more items, pick a different pattern.
+
+---
+
+## The Incremental Assembly Workflow
+
+Build the page in chunks; each insertion is small, verifiable, recoverable.
+
+1. **Create an empty draft** in WordPress.
+2. **Append the first section.** Produce its markup (pattern-schema workflow for patterns; direct block markup for prose in blog posts), then append it to the draft's existing content using the site's update/append mechanism. Read the draft's current content, concatenate the new section, and write it back — no anchors, no placeholders.
+3. **Repeat for every subsequent section.** Same append operation: read current content, append new markup, write back. Each iteration adds exactly one section.
+4. **Done.** When the last section is appended, the draft is complete. No cleanup needed.
+
+**Why append (not anchor-based search-and-replace):**
+
+- One fewer operation per section (no anchor insertion, no anchor removal).
+- Nothing to verify between steps — no "is the anchor still there?" failure mode.
+- No risk of leaving stray markers in the final document.
+- Still recoverable: if a section fails, the draft is valid up to the last successful append.
+
+**Append hygiene**: if the site's API requires sending full content, fetch it first, concatenate, then send. Do not regenerate prior sections — pass them through unchanged.
+
+**Step-by-step visual previews**: if the user asks to see a preview after each section, call `rtpwai/screenshot-post` immediately after each append. If the tool returns `not_supported`, skip silently and continue — do not fail or pause the generation flow.
+
+---
+
+## Blog Posts
+
+Prose body (paragraphs, headings, lists, quotes, inline images) uses direct block markup. Any pattern section uses the full schema workflow.
+
+1. **Ask interactively** using `ask_user_input`: topic/title (typed), audience (buttons), tone (buttons: Professional / Conversational / Educational), length (buttons: Short / Medium / Long), featured image needed (Yes / No).
+2. Use `rtpwai/get-taxonomy-terms` to fetch existing categories and tags. Fetch **all** available patterns.
+3. Resolve media.
+4. Share a plan in chat: title, hook, section-by-section structure. Mark each section as _prose_ or _pattern: \<name\>_. Get approval.
+5. Draft section content in chat (prose, headings, excerpt, proposed categories/tags, SEO fields if Yoast is active). For pattern sections, fetch/render the pattern first and size content to its slots. Get approval.
+6. Create an empty draft.
+7. For each section in order: produce markup (prose markup directly, or pattern-schema workflow for patterns), then append to the draft.
+8. Assign categories and tags using `rtpwai/set-post-terms` (taxonomy `"category"` then `"post_tag"`).
+9. **SEO & metadata (mandatory).** Always do both of the following — never skip either:
+   - Set the slug and excerpt via `rtpwai/update-post` (slug: short, keyword-rich; excerpt: 1–2 sentence meta description, max 155 chars).
+   - Attempt Yoast: call `rtpwai/set-yoast-meta` with `seo_title`, `meta_description` (max 155 chars), `focus_keyphrase`, `og_title`, `og_description`, `twitter_title`, `twitter_description`. If Yoast returns a not-active error, skip silently — the slug/excerpt from above already cover native WordPress meta.
+10. Call `rtpwai/screenshot-post` to show a final visual preview of the assembled post. If it returns `not_supported`, skip silently. **Screenshot is always the very last step.**
+11. Share the post link. Ask interactively: Publish now / Submit for review / Keep as draft.
+
+---
+
+## Landing Pages
+
+Pattern-only. No exception for "just a paragraph of text" — find the text-content pattern, or surface that none fits.
+
+1. **Ask interactively** using `ask_user_input`: purpose (typed or buttons if common types apply), audience (buttons), primary CTA label and URL (typed), sections needed (multi-select of common section types), reference pages (typed URL or "None").
+2. Fetch **all** available patterns.
+3. Render every pattern in the plan to inspect slot sizes (headline length, body length, image aspect, item count).
+4. Propose a section plan: pattern name, attributes to change, content sized to fit. Get **explicit approval**.
+5. Resolve media — list every image/video by section, search the library, ask for uploads. Don't proceed until done.
+6. Draft section content in chat, already trimmed to fit pattern slots. Get approval.
+7. Create an empty page draft.
+8. Section by section: fetch schema → render to confirm fit → mutate → render final → append.
+9. **SEO & metadata (mandatory).** Always do both of the following — never skip either:
+   - Set the slug and excerpt via `rtpwai/update-post` (slug: short, keyword-rich; excerpt: 1–2 sentence meta description, max 155 chars).
+   - Attempt Yoast: call `rtpwai/set-yoast-meta` with `seo_title`, `meta_description` (max 155 chars), `focus_keyphrase`, `og_title`, `og_description`, `twitter_title`, `twitter_description`, and `schema_page_type`. If Yoast returns a not-active error, skip silently — the slug/excerpt from above already cover native WordPress meta.
+10. Call `rtpwai/screenshot-post` to show a final visual preview of the assembled page. If it returns `not_supported`, skip silently. **Screenshot is always the very last step.**
+11. Share the page link. Ask interactively: Publish now / Keep as draft.
+
+---
+
+## Media
+
+Search the library first. Show options if multiple match. If nothing fits, ask interactively using `ask_user_input`: provide found options as buttons plus a "I'll provide a URL" option — never ask the user to type a filename or describe an image when a button will do. Never source media independently. Media IDs/URLs go into pattern schemas — not raw `<img>` tags.
+
+---
+
+## Supporting Details
+
+- **Categories & Tags** — Use `rtpwai/get-taxonomy-terms` to discover existing terms. Use `rtpwai/set-post-terms` to assign them (taxonomy `"category"` or `"post_tag"`). Create new terms only with explicit user confirmation; if confirmed, create via the WordPress REST API and then assign with `rtpwai/set-post-terms`.
+- **SEO (mandatory on every post/page)** — Always set slug and excerpt via `rtpwai/update-post` first (these work regardless of plugins). Then always attempt `rtpwai/set-yoast-meta` with: `seo_title`, `meta_description` (max 155 chars), `focus_keyphrase`, `og_title`, `og_description`, `twitter_title`, `twitter_description`. For landing pages also set `schema_page_type`. If Yoast returns a not-active error, skip silently — do not mention it to the user.
+- **Post Types** — Check registered post types first; use the relevant custom post type if one exists.
+- **Status** — Default is draft. Change only on explicit instruction (publish, pending, scheduled, private).
+- **Screenshots** — `rtpwai/screenshot-post` is always the very last step, after SEO/metadata. It returns an inline image when the feature is enabled and configured. If it returns `not_supported`, skip silently, never surface the error to the user.
+
+---
+
+## Common Mistakes to Avoid
+
+- **"I'll ask clarifying questions as a bullet list."** No. Every question with a finite set of answers goes through `ask_user_input` as buttons. Prose question lists are banned — they force the user to type when they could tap.
+- **"I'll tweak the pattern markup a little."** No. If it's not in the schema, it's not your change. Pick a different pattern.
+- **"Landing page, but this section is just text — I'll inline a paragraph."** No. Find the text-content pattern or surface that none fits.
+- **"I'll write the content first and assume it fits."** No. Render the pattern first, then size content to its slots.
+- **"I'll write the whole post body in one blob."** No. Append section by section.
+- **"A custom block would be perfect here."** Banned everywhere. Patterns only (plus prose markup in posts).
+- **"I'll add one more card to this testimonial pattern."** No. Reduce, never extend. Need more items? Pick a different pattern.
+- **"The screenshot tool failed — I should tell the user."** No. If `rtpwai/screenshot-post` returns `not_supported`, skip silently. It means the feature is not configured, not that something went wrong with the content.
+- **"I'll tell the user I'm retrying or that something errored."** No. Handle tool failures, retries, and unexpected results silently. Only report outcomes that affect the user's content.
+- **"I'll use whatever categories/tags come to mind."** No. Always call `rtpwai/get-taxonomy-terms` first to discover real existing terms before proposing or assigning any.
+- **"Yoast isn't installed so I'll skip SEO entirely."** No. Always set slug and excerpt via `rtpwai/update-post` regardless of Yoast. Then attempt `rtpwai/set-yoast-meta` — if it errors, skip silently. Never skip the slug/excerpt step.
+- **"I'll do the screenshot before setting SEO."** No. SEO and metadata always come before the screenshot. Screenshot is always the very last step.

--- a/uninstall.php
+++ b/uninstall.php
@@ -49,6 +49,7 @@ function uninstall(): void {
 	// Add additional uninstall routines here.
 	delete_options();
 	delete_transients();
+	delete_tables();
 }
 
 /**
@@ -71,11 +72,27 @@ function delete_options(): void {
 function delete_transients(): void {
 	$transients = [
 		// Add more transients as needed.
-		'@todo',
 	];
 
 	foreach ( $transients as $transient ) {
 		delete_transient( $transient );
+	}
+}
+
+/**
+ * Drops the OAuth client and token tables.
+ */
+function delete_tables(): void {
+	global $wpdb;
+
+	$tables = [
+		$wpdb->prefix . 'rtpwai_oauth_tokens',
+		$wpdb->prefix . 'rtpwai_oauth_clients',
+	];
+
+	foreach ( $tables as $table ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $table );
 	}
 }
 


### PR DESCRIPTION
## Summary

- **5 new MCP abilities** — `rtpwai/get-taxonomy-terms`, `rtpwai/get-post-terms`, `rtpwai/set-post-terms`, `rtpwai/get-yoast-meta`, `rtpwai/set-yoast-meta` — enabling AI agents to read/write WordPress taxonomy terms and Yoast SEO metadata
- **Skill file** — adds `skills/rt-publish-with-ai/SKILL.md` for distribution; defines the schema-first, incremental assembly workflow for blog posts and landing pages
- **MCP server display name** updated to "Publish With AI — rtCamp"
- **OAuth rewrite rules fix** — `flush_rewrite_rules()` now runs inside `run_migrations()` so `.well-known` endpoints are persisted to the DB immediately on activation/upgrade (previously they were only registered in memory, causing DCR `/register` 404s on first request)
- **Uninstall cleanup** — drops `rtpwai_oauth_tokens` and `rtpwai_oauth_clients` tables when the plugin is uninstalled

## Test plan

- [ ] Activate/deactivate plugin; confirm `/.well-known/oauth-authorization-server` returns JSON (not the front page)
- [ ] Connect from Claude.ai — OAuth DCR `POST /register` should succeed (no 404)
- [ ] Call `rtpwai/get-taxonomy-terms` with `taxonomy: "category"` — returns term list
- [ ] Call `rtpwai/set-post-terms` on a draft post — categories/tags assigned correctly
- [ ] Call `rtpwai/get-yoast-meta` / `rtpwai/set-yoast-meta` on a site with Yoast active — reads and writes meta fields
- [ ] Call `rtpwai/get-yoast-meta` on a site without Yoast — returns a clear error, not a PHP warning
- [ ] Uninstall plugin; confirm `rtpwai_oauth_tokens` and `rtpwai_oauth_clients` tables are gone from the DB

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22Publish%20with%20AI%20Demo%22%2C%22description%22%3A%22%40Todo%3A%20Your%20demo%20description%20goes%20here.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22plugin%22%2C%22skeleton%22%2C%22development%22%2C%22enterprise%22%5D%7D%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fpublishwithai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-19-4da5e39612b879ad5c84d8fd3709c0b33aaa8999.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->