### PR TITLE
fix(skill): remove publish ability

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -72,6 +72,7 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: rtcamp-publish-with-ai.zip
           if-no-files-found: error
+          archive: false
 
       - name: Cleanup Workspace & Home to avoid pollution
         if: always()

--- a/skills/rt-publish-with-ai/SKILL.md
+++ b/skills/rt-publish-with-ai/SKILL.md
@@ -140,7 +140,7 @@ Prose body (paragraphs, headings, lists, quotes, inline images) uses direct bloc
 9. **SEO (mandatory):**
    - Set slug and excerpt via `rtpwai/update-post` (slug: short, keyword-rich; excerpt: 1–2 sentence meta description, max 155 chars).
    - Probe Yoast: call `rtpwai/get-yoast-meta`. If it succeeds, call `rtpwai/set-yoast-meta` with `seo_title`, `meta_description` (max 155 chars), `focus_keyphrase`, `og_title`, `og_description`, `twitter_title`, `twitter_description`. If the probe fails, skip silently.
-10. **Share the post link** (from `rtpwai/get-post` → `url`). Ask interactively: Publish now / Submit for review / Keep as draft.
+10. **Share the post link** (from `rtpwai/get-post` → `url`). Do not ask to publish or change the visibility status. If user asks you to publish, tell the user you cannot do that and the publish can only be done via WordPress.
 
 ---
 
@@ -159,7 +159,7 @@ Pattern-only. No exception for "just a paragraph of text" — find a text-conten
 9. **SEO (mandatory):**
    - Set slug and excerpt via `rtpwai/update-post` (slug: short, keyword-rich; excerpt: 1–2 sentence meta description, max 155 chars).
    - Probe Yoast: call `rtpwai/get-yoast-meta`. If it succeeds, call `rtpwai/set-yoast-meta` with `seo_title`, `meta_description` (max 155 chars), `focus_keyphrase`, `og_title`, `og_description`, `twitter_title`, `twitter_description`, and `schema_page_type`. If the probe fails, skip silently.
-10. **Share the page link** (from `rtpwai/get-post` → `url`). Ask interactively: Publish now / Keep as draft.
+10. **Share the page link** (from `rtpwai/get-post` → `url`).
 
 ---
 
@@ -178,7 +178,7 @@ Media IDs/URLs go into pattern schemas, never raw `<img>` tags.
 - **Categories & Tags** — Always call `rtpwai/get-taxonomy-terms` first to discover real existing terms before proposing or assigning any. Use `rtpwai/set-post-terms` to assign (taxonomy `"category"` or `"post_tag"`). Create new terms only with explicit user confirmation; if confirmed, create via the WordPress REST API and then assign with `rtpwai/set-post-terms`.
 - **SEO is mandatory on every post and page.** Always set slug and excerpt via `rtpwai/update-post` (works regardless of plugins). Always probe Yoast with `rtpwai/get-yoast-meta` — if it succeeds, set all fields with `rtpwai/set-yoast-meta`. If the probe fails, skip silently. Never skip slug/excerpt just because Yoast isn't active.
 - **Post Types** — Check registered post types first; use the relevant custom post type if one exists.
-- **Status** — Default is draft. Change only on explicit instruction (publish, pending, scheduled, private).
+- **Status** — Default is draft. You cannot change that even if the user asks..
 
 ---
 


### PR DESCRIPTION
<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22Publish%20With%20AI%20Demo%22%2C%22description%22%3A%22%40Todo%3A%20Your%20demo%20description%20goes%20here.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22plugin%22%2C%22skeleton%22%2C%22development%22%2C%22enterprise%22%5D%7D%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fpublish-with-ai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-39-cf82cb635efc03823af7360357bf10cd661219dc.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->