### PR TITLE
release(0.4.1): update readme and gh workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     name: Create WordPress.org release
     needs: [validate, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "rtcamp/publishio",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fef6724eed7878ce90250eb4599e8608",
+    "content-hash": "98131f5b3cc64f759db94660dc914c47",
     "packages": [
         {
             "name": "cweagans/composer-configurable-plugin",

--- a/publishio.php
+++ b/publishio.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Publishio
  * Plugin URI:        https://github.com/rtCamp/publishio
  * Description:       Build WordPress pages and posts using your existing patterns directly from your favorite AI assistant.
- * Version:           0.4.0
+ * Version:           0.4.1
  * Author:            rtCamp
  * Author URI:        https://rtcamp.com
  * License:           GPL-2.0-or-later
@@ -41,7 +41,7 @@ function constants(): void {
 	/**
 	 * Version of the plugin.
 	 */
-	define( 'PUBLISHIO_VERSION', '0.4.0' );
+	define( 'PUBLISHIO_VERSION', '0.4.1' );
 
 	/**
 	 * Root path to the plugin directory.

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Requires PHP:      8.2
 Requires at least: 6.9
 Tested up to:      7.0
-Stable tag:        0.4.0
+Stable tag:        0.4.1
 
 Connect any AI to WordPress and build pages and posts from your site's own block patterns, without changing your design.
 
@@ -115,11 +115,14 @@ The source code is available on <a href="https://github.com/rtCamp/publishio">Gi
 == Screenshots ==
 
 1. The Publishio Guide page in the WordPress dashboard — lists available AI setup guides.
-2. The Claude AI setup guide showing how to add a custom MCP connector in Claude's Customize → Connectors panel.
+2. The Claude AI setup guide showing how to add a custom MCP connector in Claude's Customize > Connectors panel.
 3. The WordPress OAuth authorization screen, where Claude requests access to your site via the Publishio MCP server.
 4. The Connections page listing all AI apps that have authenticated with your site, with user, registration date, and last-active details.
 
 == Changelog ==
+
+= 0.4.1 =
+* Fix readme.txt
 
 = 0.4.0 =
 * Release plugin on WordPress.org.


### PR DESCRIPTION
## Summary
- Fix readme.txt issue
- Increase release GH action timeout.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22Publishio%20Demo%22%2C%22description%22%3A%22Connect%20any%20AI%20to%20WordPress%20and%20build%20pages%20and%20posts%20from%20your%20site&#039;s%20own%20block%20patterns%2C%20without%20changing%20your%20design.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22Publish%22%2C%22AI%22%2C%22Editorial%20Workflow%22%2C%22Abilities%22%2C%22MCP%22%5D%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dpublishio%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22plugins%22%3A%5B%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fpublishio%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-68-f01b17897305cdc1b2a819c89d000d5f3dbab828.zip%22%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->