### PR TITLE
Run Copilot code review on GitHub-hosted runners

### DIFF
--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -1,0 +1,22 @@
+name: Copilot code review setup steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+
+jobs:
+  # The job must be named `copilot-setup-steps`, or Copilot ignores this file.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Start Review
+        run: echo "Starting Review."


### PR DESCRIPTION
This repository is public, so Copilot code review cannot use rtCamp self-hosted Actions Runner Controller scale sets, which are not exposed to public repositories.

Adds `.github/workflows/copilot-code-review.yml`, which pins Copilot code review to `ubuntu-latest`. The file takes precedence over `copilot-setup-steps.yml` and over the organization-level runner type for Copilot code review only; Copilot cloud agent keeps using the organization configuration.

No dependencies are installed: Copilot clones the repository and provisions what it needs itself. Repository-specific setup steps can be added to this file later if a review needs extra tooling.

Docs: https://docs.github.com/en/copilot/how-tos/copilot-on-github/set-up-copilot/configure-runners

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22Publishio%20Demo%22%2C%22description%22%3A%22Connect%20any%20AI%20to%20WordPress%20and%20build%20pages%20and%20posts%20from%20your%20site&#039;s%20own%20block%20patterns%2C%20without%20changing%20your%20design.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22Publish%22%2C%22AI%22%2C%22Editorial%20Workflow%22%2C%22Abilities%22%2C%22MCP%22%5D%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dpublishio%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22plugins%22%3A%5B%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fpublishio%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-97-5d1ec906ff4948ee7392ca6707dffffbdbdacd40.zip%22%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->