### PR TITLE
release(1.0.0): bump plugin version and WordPress tested version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE.md)
 [![PHP](https://img.shields.io/badge/PHP-8.2%2B-blue?logo=php)](composer.json)
-[![WordPress](https://img.shields.io/badge/WordPress-7.0-blue?logo=wordpress)](https://wordpress.org)<br>
+[![WordPress](https://img.shields.io/badge/WordPress-7.1-blue?logo=wordpress)](https://wordpress.org)<br>
 [![CI](https://github.com/rtCamp/publishio/actions/workflows/ci.yml/badge.svg)](https://github.com/rtCamp/publishio/actions/workflows/ci.yml)
 [![GitHub commits since latest release](https://img.shields.io/github/commits-since/rtCamp/publishio/latest)](https://github.com/rtCamp/publishio/releases)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "rtcamp/publishio",
-	"version": "0.4.1",
+	"version": "1.0.0",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c23a09a7b58dfc371a8b4fa5b1878fee",
+    "content-hash": "4f0163fe7553e699e22474ab9d454ff2",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",

--- a/publishio.php
+++ b/publishio.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Publishio
  * Plugin URI:        https://github.com/rtCamp/publishio
  * Description:       Build WordPress pages and posts using your existing patterns directly from your favorite AI assistant.
- * Version:           0.4.1
+ * Version:           1.0.0
  * Author:            rtCamp
  * Author URI:        https://rtcamp.com
  * License:           GPL-2.0-or-later
@@ -19,7 +19,7 @@
  * Domain Path:       /languages
  * Requires PHP:      8.2
  * Requires at least: 6.9
- * Tested up to:      7.0
+ * Tested up to:      7.1
  */
 
 declare( strict_types = 1 );
@@ -41,7 +41,7 @@ function constants(): void {
 	/**
 	 * Version of the plugin.
 	 */
-	define( 'PUBLISHIO_VERSION', '0.4.1' );
+	define( 'PUBLISHIO_VERSION', '1.0.0' );
 
 	/**
 	 * Root path to the plugin directory.

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Requires PHP:      8.2
 Requires at least: 6.9
-Tested up to:      7.0
-Stable tag:        0.4.1
+Tested up to:      7.1
+Stable tag:        1.0.0
 
 Connect any AI to WordPress and build pages and posts from your site's own block patterns, without changing your design.
 
@@ -121,6 +121,10 @@ The source code is available on <a href="https://github.com/rtCamp/publishio">Gi
 
 == Changelog ==
 
+= 1.0.0 =
+* Declare the plugin stable with the 1.0.0 release.
+* Test the plugin with WordPress 7.1.
+
 = 0.4.1 =
 * Fix readme.txt
 
@@ -144,6 +148,9 @@ The source code is available on <a href="https://github.com/rtCamp/publishio">Gi
 * AI Skill file for guided content generation.
 
 == Upgrade Notice ==
+
+= 1.0.0 =
+* First stable release. No upgrade steps required.
 
 = 0.4.0 =
 * Release plugin on WordPress.org.


### PR DESCRIPTION
## Summary

- Bump plugin version to 1.0.0.
- Update WordPress tested version to 7.1.
- Add changelog and upgrade notice entries for 1.0.0.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22Publishio%20Demo%22%2C%22description%22%3A%22Connect%20any%20AI%20to%20WordPress%20and%20build%20pages%20and%20posts%20from%20your%20site&#039;s%20own%20block%20patterns%2C%20without%20changing%20your%20design.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22Publish%22%2C%22AI%22%2C%22Editorial%20Workflow%22%2C%22Abilities%22%2C%22MCP%22%5D%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dpublishio%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22plugins%22%3A%5B%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fpublishio%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-105-9b7828af2d2d4a2a380910c37756adf73ba18724.zip%22%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->